### PR TITLE
Handle broken process pool in diffing server well

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+In Development
+--------------
+
+- Fixes an issue where the diffing server could reset the process pool that manages the actual diffs multiple times unnecessarily, leading to wasted memory and CPU. If you are tracking logs and errors, this will also make error messages about the diffing server clearer — you’ll see “BrokenProcessPool” instead of “'NoneType' object does not support item assignment.” (`#38 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/38>`)
+
+
 Version 0.1.0
 -------------
 

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,7 +5,7 @@ Release History
 In Development
 --------------
 
-- Fixes an issue where the diffing server could reset the process pool that manages the actual diffs multiple times unnecessarily, leading to wasted memory and CPU. If you are tracking logs and errors, this will also make error messages about the diffing server clearer — you’ll see “BrokenProcessPool” instead of “'NoneType' object does not support item assignment.” (`#38 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/38>`)
+- Fixes an issue where the diffing server could reset the process pool that manages the actual diffs multiple times unnecessarily, leading to wasted memory and CPU. If you are tracking logs and errors, this will also make error messages about the diffing server clearer — you’ll see “BrokenProcessPool” instead of “'NoneType' object does not support item assignment.” (`#38 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/38>`_)
 
 
 Version 0.1.0


### PR DESCRIPTION
We previously tried to reset the process pool for diffing every time it broke, and failed to handle the case where we exhausted all our retries. We now don't reset the pool and instead raise an exception on the last try, preventing weird errors from happening later on because we returned a bad value (`None`) from `DiffHandler.diff()`.

This also does a little more work to ensure that we aren't thrashing the process pool when a lot of diffs are happening simultaneously. We previously had each diff blindly reset the pool, which means that if multiple diffs were in flight when the pool broke, it would get reset multiple times, even though it really only needed to get reset once. This was probably wasting a lot of memory and CPU time.

Note that the tests here don't really test the first issue. There's not a good way to differentiate from the outside whether an unknown error was the process pool or something else.

Fixes #33.