### PR TITLE
HTML diff: Maintain spacing in text/tags

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,8 @@ In Development
 
 - Fixes an issue where the diffing server could reset the process pool that manages the actual diffs multiple times unnecessarily, leading to wasted memory and CPU. If you are tracking logs and errors, this will also make error messages about the diffing server clearer — you’ll see “BrokenProcessPool” instead of “'NoneType' object does not support item assignment.” (`#38 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/38>`_)
 
+- Fixes :func:`web_monitoring_diff.html_diff_render` to make sure the spacing of text and tags in the HTML source code of the diff matches the original. This resolves display issues on pages where CSS is used to treat spacing as significant. (`#36 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/36>`_)
+
 
 Version 0.1.0
 -------------


### PR DESCRIPTION
It turns out that some of the display breakage we've had with `html_render_diff` is happening because we are nicely reformatting the source on pages that use `white-space: pre;` or similar CSS styling to treat the spacing in the source code as significant. For example, the following will display poorly, but it's what we were outputting:

    <!-- Before Version -->
    <div style="white-space: pre;">Some text</div>
    
    <!-- Before Version -->
    <div style="white-space: pre;"></div>
    
    <!-- Diff Output -->
    <div style="white-space: pre;">
      <del>
        Some text
      </del>
    </div>

Solve this by working harder to maintain the original spacing and not unintentionally reformatting the source, so we now output:

    <!-- Diff Output -->
    <div style="white-space: pre;"><del>Some text</del></div>

Fixes #36.