### PR TITLE
Fix graceful server shutdown

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,8 @@ In Development
 
 - Fixes an issue where the diffing server could reset the process pool that manages the actual diffs multiple times unnecessarily, leading to wasted memory and CPU. If you are tracking logs and errors, this will also make error messages about the diffing server clearer — you’ll see “BrokenProcessPool” instead of “'NoneType' object does not support item assignment.” (`#38 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/38>`_)
 
+- Ensures the server shuts down gracefully when pressing ctrl+c or sending a SIGINT signal. (`#44 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/44>`_)
+
 - Fixes :func:`web_monitoring_diff.html_diff_render` to make sure the spacing of text and tags in the HTML source code of the diff matches the original. This resolves display issues on pages where CSS is used to treat spacing as significant. (`#36 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/36>`_)
 
 - Improve handling of lazy-loaded images in :func:`web_monitoring_diff.html_diff_render`. When images are lazy-loaded via JS, they usually use the ``data-src`` or ``data-srcset`` attributes, and we now check those, too. Additionally, if two images have no detectable URLs, we now treat them as the same, rather than different. (`#37 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/37>`_)


### PR DESCRIPTION
At some point, our server's graceful shutdown logic broke. This fixes a couple issues:
- If a diff is in progress while the server is shutting down, it's possible for the diff retry mechanism to fight with the server about shutting down or starting up the process pool for diffing.
- The SIGINT signal for ctrl+c is getting passed down to the worker processes in the diff pool, which did not used to happen. We now add explicit initialization code to the workers so they ignore the signal, since the main server process will handle it and tell the workers what to do.