### PR TITLE
Add missing certifi requirement

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -9,5 +9,6 @@
 # setup.py.
 cchardet >=2.1.6,<3
 pycurl >=7.43,<8
+certifi >=2020.11.8
 sentry-sdk >=0.14.0,<1.0
 tornado >=6.0.0,<7


### PR DESCRIPTION
When creating a new venv and trying to run the server, `sentry-sdk`
raises an exception `ModuleNotFoundError: No module named 'certifi'`