### PR TITLE
Crash diff server when its process pool dies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,15 @@
-# All environmental variables are optional. The associated settings can be
-# updated at runtime. These merely provide defaults at import time.
-
-
-# These are used in the web_monitoring.db module.
-# They can point to a local deployment of web-monitoring-db (as in this
-# example) or to the production deployment.
-export WEB_MONITORING_DB_URL="http://localhost:3000"
-export WEB_MONITORING_DB_EMAIL="seed-admin@example.com"
-export WEB_MONITORING_DB_PASSWORD="PASSWORD"
-export WEB_MONITORING_APP_ENV="development"  # or production or test
-
-# These are used in test_html_diff
-export WEB_MONITORING_DB_STAGING_URL="https://api-staging.monitoring.envirodatagov.org"
-export WEB_MONITORING_DB_STAGING_EMAIL=""
-export WEB_MONITORING_DB_STAGING_PASSWORD=""
-
+# All environment variables are optional. The associated settings can be
+# updated at runtime. These provide a friendly interface to changing settings
+# when running commands from a CLI.
 
 # Diff-Related variables --------------------------
+
+# These CSS color values are used to set the colors in html_diff_render, differs and links_diff
+# export DIFFER_COLOR_INSERTION="#4dac26"
+# export DIFFER_COLOR_DELETION="#d01c8b"
+
+
+# Server-Related variables ------------------------
 
 # Set the diffing server to debug mode. Returns tracebacks in error responses
 # and auto-reloads the server when source files change.
@@ -38,13 +31,9 @@ export DIFFER_MAX_BODY_SIZE='10485760' # 10 MB
 # https:// requests have invalid certificates.
 # export VALIDATE_TARGET_CERTIFICATES="false"
 
-# These CSS color values are used to set the colors in html_diff_render, differs and links_diff
-# export DIFFER_COLOR_INSERTION="#4dac26"
-# export DIFFER_COLOR_DELETION="#d01c8b"
-
 # Set how many diffs can be run in parallel.
 # export DIFFER_PARALLELISM=10
 
-# Uncomment to enable logging. Set the level as any normal level.
-# https://docs.python.org/3.6/library/logging.html#logging-levels
-# export LOG_LEVEL=INFO
+# Instead of crashing when the process pool used for running diffs breaks,
+# keep accepting requests and try to restart the pool.
+# RESTART_BROKEN_DIFFER='true'

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+In Development
+--------------
+
+- The server uses a pool of child processes to run diffs. If the pool breaks while running a diff, it will be re-created once, and, if it fails again, the server will now crash with an exit code of ``10``. (An external process manager like Supervisor, Kubernetes, etc. can then decide how to handle the situation.) Previously, the diff would fail at this point, but server would try to re-create the process pool again the next time a diff was requested. You can opt-in to the old behavior by setting the ``RESTART_BROKEN_DIFFER`` environment variable to ``true``. (`#49 <https://github.com/edgi-govdata-archiving/web-monitoring-diff/issues/49>`_)
+
+
 Version 0.1.1 (2020-11-24)
 --------------------------
 


### PR DESCRIPTION
If the server's process pool (used for actually running the diffs) fails repeatedly, assume it just can't be started and crash the whole server so a process manager can clean things up and totally start over. You can retain the old behavior (where the server keeps trying to start a new process pool if the old one is broken) by setting the `RESTART_BROKEN_DIFFER` environment variable to `true`.

Fixes #42.