### PR TITLE
Update circleci base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Install System Dependencies
           command: |
-            apt-get install \
+            sudo apt-get install \
               libxml2-dev libxslt-dev libssl-dev openssl libcurl4-openssl-dev
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - run:
           name: Install System Dependencies
           command: |
+            sudo apt-get update
             sudo apt-get install \
               libxml2-dev libxslt-dev libssl-dev openssl libcurl4-openssl-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@ jobs:
       - image: cimg/python:3.7
     steps:
       - checkout
+      - run:
+          name: Install System Dependencies
+          command: |
+            apt-get install \
+              libxml2-dev libxslt-dev libssl-dev openssl libcurl4-openssl-dev
+
       - restore_cache:
           keys:
             - cache-v2-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-experimental.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,16 @@ jobs:
   build:
     working_directory: ~/web-monitoring-diff
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
     steps:
       - checkout
       - restore_cache:
           keys:
-            - cache-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-experimental.txt" }}
-            - cache-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-{{ checksum "requirements-dev.txt" }}-
-            - cache-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-
-            - cache-v1-{{ arch }}-{{ checksum "requirements.txt" }}-
-            - cache-v1-{{ arch }}-
+            - cache-v2-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-experimental.txt" }}
+            - cache-v2-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-{{ checksum "requirements-dev.txt" }}-
+            - cache-v2-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-
+            - cache-v2-{{ arch }}-{{ checksum "requirements.txt" }}-
+            - cache-v2-{{ arch }}-
 
       # Bundle install dependencies
       - run:
@@ -25,7 +25,7 @@ jobs:
 
       # Store bundle cache
       - save_cache:
-          key: cache-v1-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-experimental.txt" }}
+          key: cache-v2-{{ arch }}-{{ checksum "requirements.txt" }}-{{ checksum "requirements-server.txt" }}-{{ checksum "requirements-dev.txt" }}-{{ checksum "requirements-experimental.txt" }}
           paths:
             - venv
 


### PR DESCRIPTION
The old `circleci/*` images have finally been deprecated, so it's past time to switch over.