### PR TITLE
Ignore `application/x-download` content type

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -7,6 +7,8 @@ In Development
 
 - Ignore invalid `Content-Type` headers when diffing HTML. (:issue:`75`)
 
+- Ignore `application/x-download` Content-Type when diffing HTML.
+
 
 Version 0.1.2 (2021-04-01)
 -----------------------------

--- a/web_monitoring_diff/content_type.py
+++ b/web_monitoring_diff/content_type.py
@@ -38,6 +38,7 @@ ACCEPTABLE_CONTENT_TYPES = (
 # Matches Content Types that *could* be acceptable for diffing as HTML
 UNKNOWN_CONTENT_TYPE_PATTERN = re.compile(r'^(%s)$' % '|'.join((
     r'application/octet-stream',
+    r'application/x-download',
     r'text/.+'
 )))
 


### PR DESCRIPTION
The `application/x-download` content type doesn't really carry any meaningful information about the content, and should be ignored in favor of sniffing when checking whether a document might be diffable HTML.