### PR TITLE
Update fast_diff_match_patch

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,9 +5,9 @@ Release History
 In Development
 --------------
 
-- Updates the diff-match-patch implementation we rely on for simple text diffs to `fast_diff_match_patch v2.x <https://pypi.org/project/fast-diff-match-patch/>`_. (:issue:`127`)
+- Updates the diff-match-patch implementation we rely on for simple text diffs to `fast_diff_match_patch v2.x <https://pypi.org/project/fast-diff-match-patch/>`_. (:issue:`126`)
 
-- Fix misconfigured dependency requirements for html5-parser. This should have no user impact, since there are no releases (yet) in the version range we were accidentally allowing for. (:issue:`127`)
+- Fix misconfigured dependency requirements for html5-parser. This should have no user impact, since there are no releases (yet) in the version range we were accidentally allowing for. (:issue:`126`)
 
 
 Version 0.1.3 (2022-04-18)

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -5,7 +5,9 @@ Release History
 In Development
 --------------
 
-- Updates the diff-match-patch implementation we rely on for simple text diffs to `fast_diff_match_patch v2.x <https://pypi.org/project/fast-diff-match-patch/>`_.
+- Updates the diff-match-patch implementation we rely on for simple text diffs to `fast_diff_match_patch v2.x <https://pypi.org/project/fast-diff-match-patch/>`_. (:issue:`127`)
+
+- Fix misconfigured dependency requirements for html5-parser. This should have no user impact, since there are no releases (yet) in the version range we were accidentally allowing for. (:issue:`127`)
 
 
 Version 0.1.3 (2022-04-18)

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,6 +2,12 @@
 Release History
 ===============
 
+In Development
+--------------
+
+- Updates the diff-match-patch implementation we rely on for simple text diffs to `fast_diff_match_patch v2.x <https://pypi.org/project/fast-diff-match-patch/>`_.
+
+
 Version 0.1.3 (2022-04-18)
 --------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@
 # It only exists to keep the list of dependencies in a separate file from
 # setup.py.
 beautifulsoup4 >=4.9.0,<5
-diff_match_patch_python >=1.0.2,<2
-html5-parser >=0.4.0,<5 --no-binary lxml
+fast_diff_match_patch >=2.0.1,<3
+html5-parser >=0.4.0,<0.5 --no-binary lxml
 lxml >=4.5.0,<5

--- a/web_monitoring_diff/basic_diffs.py
+++ b/web_monitoring_diff/basic_diffs.py
@@ -1,5 +1,5 @@
 from bs4 import Comment
-from diff_match_patch import diff, diff_bytes
+from fast_diff_match_patch import diff
 import html5_parser
 import re
 import sys
@@ -58,11 +58,9 @@ def side_by_side_text(a_text, b_text):
 
 
 def compute_dmp_diff(a_text, b_text, timelimit=4):
-    if (isinstance(a_text, str) and isinstance(b_text, str)):
-        changes = diff(a_text, b_text, checklines=False, timelimit=timelimit, cleanup_semantic=True, counts_only=False)
-    elif (isinstance(a_text, bytes) and isinstance(b_text, bytes)):
-        changes = diff_bytes(a_text, b_text, checklines=False, timelimit=timelimit, cleanup_semantic=True,
-                             counts_only=False)
+    if (isinstance(a_text, (str, bytes)) and isinstance(b_text, (str, bytes))):
+        changes = diff(a_text, b_text, checklines=False, timelimit=timelimit, cleanup="Semantic",
+                       counts_only=False)
     else:
         raise TypeError("Both the texts should be either of type 'str' or 'bytes'.")
 


### PR DESCRIPTION
The `diff_match_patch_python` package was renamed to `fast_diff_match_patch`. This updates it and switches to the new name (it was out-of-date enough to trigger deprecation warnings on some Python versions).

I also fixed a typo in the version constraints for html5-parser while doing this.