### PR TITLE
Fix Sphinx build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,9 +81,9 @@ extlinks = {
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable', None),
-    'matplotlib': ('https://matplotlib.org', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
 }
 
 


### PR DESCRIPTION
Read The Docs was able to build fine, but our own Makefile was not actually working due to a missing `_static` directory. This also updates the Intersphinx mappings since they have changed, and the old configuration was generating warnings.