### PR TITLE
Add Python 3.11 to our testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   primary-python-version:
     type: string
-    default: "3.10.7"
+    default: "3.11.0"
 
 commands:
   setup_pip:
@@ -179,7 +179,7 @@ workflows:
               only: /^v.*/
           matrix:
             parameters:
-              python-version: ["3.7", "3.8", "3.9", "3.10"]
+              python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       - lint:
           filters:
             tags:


### PR DESCRIPTION
3.11 is out now, so we should make sure we are testing on it and supporting it!