### PR TITLE
Update default CI Python to 3.10.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   primary-python-version:
     type: string
-    default: "3.10.7"
+    default: "3.10.11"
 
 commands:
   setup_pip:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # We separate them out so that the final `release` image can layer on top of
 # this one without needing compiler-related packages.
 ##
-FROM python:3.10.7-slim as base
+FROM python:3.10.11-slim as base
 LABEL maintainer="enviroDGI@gmail.com"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Updates the default Python version for CI jobs like linting and building to 3.10.11 (latest 3.10 release as of this writing).