### PR TITLE
Light cleanup on html_render_diff.py

### DIFF
--- a/web_monitoring_diff/html_render_diff.py
+++ b/web_monitoring_diff/html_render_diff.py
@@ -554,10 +554,8 @@ def _htmldiff(old, new, comparator, include='all'):
     """
     old_tokens = tokenize(old, comparator)
     new_tokens = tokenize(new, comparator)
-    # old_tokens = [_customize_token(token) for token in old_tokens]
-    # new_tokens = [_customize_token(token) for token in new_tokens]
-    old_tokens = _limit_spacers(_customize_tokens(old_tokens), MAX_SPACERS)
-    new_tokens = _limit_spacers(_customize_tokens(new_tokens), MAX_SPACERS)
+    old_tokens = _limit_spacers(_insert_spacers(old_tokens), MAX_SPACERS)
+    new_tokens = _limit_spacers(_insert_spacers(new_tokens), MAX_SPACERS)
     # result = htmldiff_tokens(old_tokens, new_tokens)
     # result = diff_tokens(old_tokens, new_tokens) #, include='delete')
     logger.debug('CUSTOMIZED!')
@@ -1044,7 +1042,17 @@ class ImgTagToken(tag_token):
         return super().__hash__()
 
 
-def _customize_tokens(tokens):
+# FIXME: Add a `max` parameter or similar to limit the number of spacers. We
+# currently do this by making a second pass to remove extra spacers
+# (in `_limit_spacers()`), which is completely pointless extra work, and very
+# expensive on big HTML documents.
+#
+# TODO: This entire bit of functionality should be rethought. The spacers were
+# a bit of a hack from the early days when we were slightly customizing lxml's
+# differ, and we've since changed the internals a lot. The spacers have never
+# worked especially well, and we may be better off without them. This needs
+# *lots* of testing, though.
+def _insert_spacers(tokens):
     SPACER_STRING = '\nSPACER'
 
     result = []

--- a/web_monitoring_diff/html_render_diff.py
+++ b/web_monitoring_diff/html_render_diff.py
@@ -619,8 +619,9 @@ def _count_changes(opcodes):
 # lxml.html.diff. We plan to change it significantly.
 
 def expand_tokens(tokens, equal=False):
-    """Given a list of tokens, return a generator of the chunks of
-    text for the data in the tokens.
+    """
+    Given a list of tokens, return a generator of the chunks of text for the
+    data in the tokens.
     """
     for token in tokens:
         for pre in token.pre_tags:
@@ -635,7 +636,8 @@ def expand_tokens(tokens, equal=False):
 
 
 class DiffToken(str):
-    """ Represents a diffable token, generally a word that is displayed to
+    """
+    Represents a diffable token, generally a word that is displayed to
     the user.  Opening tags are attached to this token when they are
     adjacent (pre_tags) and closing tags that follow the word
     (post_tags).  Some exceptions occur when there are empty tags
@@ -645,7 +647,8 @@ class DiffToken(str):
     We also keep track of whether the word was originally followed by
     whitespace, even though we do not want to treat the word as
     equivalent to a similar word that does not have a trailing
-    space."""
+    space.
+    """
 
     # When this is true, the token will be eliminated from the
     # displayed diff if no change has occurred:
@@ -677,10 +680,11 @@ class DiffToken(str):
 
 
 class tag_token(DiffToken):
-
-    """ Represents a token that is actually a tag.  Currently this is just
+    """
+    Represents a token that is actually a tag.  Currently this is just
     the <img> tag, which takes up visible space just like a word but
-    is only represented in a document by a tag.  """
+    is only represented in a document by a tag.
+    """
 
     def __new__(cls, tag, data, html_repr, comparator, pre_tags=None,
                 post_tags=None, trailing_whitespace=""):
@@ -708,8 +712,10 @@ class tag_token(DiffToken):
 
 
 class href_token(DiffToken):
-    """ Represents the href in an anchor tag.  Unlike other words, we only
-    show the href when it changes.  """
+    """
+    Represents the href in an anchor tag.  Unlike other words, we only
+    show the href when it changes.
+    """
 
     hide_when_equal = True
 
@@ -851,12 +857,14 @@ def fixup_chunks(chunks, comparator):
 
 
 def flatten_el(el, include_hrefs, skip_tag=False):
-    """ Takes an lxml element el, and generates all the text chunks for
+    """
+    Takes an lxml element el, and generates all the text chunks for
     that tag.  Each start tag is a chunk, each word is a chunk, and each
     end tag is a chunk.
 
     If skip_tag is true, then the outermost container tag is
-    not returned (just its contents)."""
+    not returned (just its contents).
+    """
     if not skip_tag:
         if el.tag == 'img':
             src_array = []
@@ -899,8 +907,10 @@ def flatten_el(el, include_hrefs, skip_tag=False):
 split_words_re = re.compile(r'\S+(?:\s+|$)', re.U)
 
 def split_words(text):
-    """ Splits some text into words. Includes trailing whitespace
-    on each word when appropriate.  """
+    """
+    Splits some text into words. Includes trailing whitespace on each word when
+    appropriate.
+    """
     if not text or not text.strip():
         return []
 
@@ -918,8 +928,10 @@ def start_tag(el):
                          for name, value in el.attrib.items()]))
 
 def end_tag(el):
-    """ The text representation of an end tag for a tag.  Includes
-    trailing whitespace when appropriate.  """
+    """
+    The text representation of an end tag for a tag.  Includes trailing
+    whitespace when appropriate.
+    """
     if el.tail and start_whitespace_re.search(el.tail):
         extra = ' '
     else:

--- a/web_monitoring_diff/html_render_diff.py
+++ b/web_monitoring_diff/html_render_diff.py
@@ -595,12 +595,24 @@ def _htmldiff(old, new, comparator, include='all'):
 # tokenization phase, though.
 def _limit_spacers(tokens, max_spacers):
     limited_tokens = []
+    extra_pre_tags = []
     for token in tokens:
         if isinstance(token, SpacerToken):
             if max_spacers <= 0:
+                extra_pre_tags.extend(token.pre_tags)
+                extra_pre_tags.extend(token.post_tags)
                 continue
             max_spacers -= 1
+
+        if len(extra_pre_tags):
+            token.pre_tags = [*extra_pre_tags, *token.pre_tags]
+            extra_pre_tags.clear()
+
         limited_tokens.append(token)
+
+    if len(extra_pre_tags):
+        last = limited_tokens[-1]
+        last.post_tags = [*last.post_tags, *extra_pre_tags]
 
     return limited_tokens
 

--- a/web_monitoring_diff/html_render_diff.py
+++ b/web_monitoring_diff/html_render_diff.py
@@ -1905,7 +1905,7 @@ def get_diff_styles():
         script {{display: none !important;}}'''
 
 
-UPDATE_CONTRAST_SCRIPT = """
+UPDATE_CONTRAST_SCRIPT = r"""
     (function () {
         // Update the text color of change elements to ensure a readable level
         // of contrast with the background color


### PR DESCRIPTION
There’s a stupendous amount of cleanup work I’ve been meaning to circle back and do in `html_render_diff.py` for YEARS. This is a start.

I plan to keep this PR *relatively* narrowly focused on refactoring, removing/replacing vestigial code, and style fixes. I’m *not* going to make significant behavior changes here (e.g. potentially changing the “spacer” concept, which needs a major rethink). Changes like that need a lot more careful consideration and testing, and I need time to get my head back into this space in order to do that well.

Work in progress. Still a little more to do here, although I don’t want to bit off *too* much. I want to:

- [ ] Look at removing `_limit_spacers()` and merging it into `_insert_spacers()` (good performance gain to be had there).

- [ ] We tokenize in two steps that could potentially be one: `flatten_el` turns a DOM tree into an iterator of `(token_type, extra_info)` tuples. Then, `fixup_chunks()` turns those tuples into token objects to be diffed. https://github.com/edgi-govdata-archiving/web-monitoring-diff/blob/cb359af8d66a7e593a6a203eb4aeb5a0535bd179/web_monitoring_diff/html_render_diff.py#L767-L770

    This was done back in the day when we used tokenization from inside lxml and added our own extras on top. We no longer do that, and it’s possible the code may be clearer if we combine these steps. It also might not be! I want to prototype this and see how it feels. (Important: I don’t think there’s a big performance gain to be had here, since the first step produces an iterator that we use pretty efficiently. But we could probably reduce some object allocations for the tuples, though.)

- [ ] Consider fixing the double parsing we do when tokenizing…

    `diff_elements()` calls `_diffable_fragment()`, which turns a soup DOM into a string, and passes that to `_htmldiff()`: https://github.com/edgi-govdata-archiving/web-monitoring-diff/blob/cb359af8d66a7e593a6a203eb4aeb5a0535bd179/web_monitoring_diff/html_render_diff.py#L518-L521

    Then `_htmldiff()` calls `tokenize()` on that string: https://github.com/edgi-govdata-archiving/web-monitoring-diff/blob/cb359af8d66a7e593a6a203eb4aeb5a0535bd179/web_monitoring_diff/html_render_diff.py#L555-L556

    Then `tokenize()` calls `parse_html()` on the string to make it an etree DOM: https://github.com/edgi-govdata-archiving/web-monitoring-diff/blob/cb359af8d66a7e593a6a203eb4aeb5a0535bd179/web_monitoring_diff/html_render_diff.py#L763-L768

    One complexity here is that we start by dealing with a beatifulsoup DOM, then the lower-level code is designed to deal with an etree DOM. The structure of these two is not the same, and that may introduce issues. etree leaves spaces mostly untouched, but beautifulsoup does some space cleanup. etree elements also have a `text` and `tail`, while beautifulsoup deals with a mix of tags and strings (and other node types). This may be introduce enough complexity that this should be tackled separately. Needs examination.