### PR TITLE
Check/fix ReadTheDocs.io builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
   apt_packages:
     - libxml2-dev
     - libxslt-dev
@@ -18,6 +18,9 @@ build:
 
 python:
   install:
+    # Install first to make sure the --no-binary option is used for html5-parser/lxml.
+    # (The option is not preserved when installing from the wayback package definition.)
+    # - requirements: "requirements.txt"
     - method: pip
       path: "."
       extra_requirements:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
   apt_packages:
     - libxml2-dev
     - libxslt-dev

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,7 @@ python:
   install:
     # Install first to make sure the --no-binary option is used for html5-parser/lxml.
     # (The option is not preserved when installing from the wayback package definition.)
-    # - requirements: "requirements.txt"
+    - requirements: "requirements.txt"
     - method: pip
       path: "."
       extra_requirements:


### PR DESCRIPTION
It looks like some change on ReadTheDocs is causing builds there to fail because lxml and html5-parser aren’t building together. Double-check this and maybe fix the issue by managing how dependencies are installed.