### PR TITLE
Use `--no-binary` option on ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,15 +16,13 @@ build:
     - openssl
     - libcurl4-openssl-dev
   jobs:
-    pre_install:
-      # Use a pre-install step so we can specify the `--no-binary` option, which is
-      # not possible a pip entry in the `python.install` section of this config file.
-      - pip install '.[server,docs]' --no-binary lxml
-
-python:
-  install:
-    # Also add experimental features.
-    - requirements: "requirements-experimental.txt"
+    post_install:
+      # Use a post-install step so we can specify the `--no-binary` option, which is not
+      # possible in a pip entry in the `python.install` section of this config file.
+      - python -m pip install '.[server,docs]' --no-binary lxml
+      # Experimental dependencies are not supported in standard package metadata, so we
+      # need to pip install them directly.
+      - python -m pip install -r requirements-experimental.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,12 +17,12 @@ build:
     - libcurl4-openssl-dev
   jobs:
     post_install:
-      # Use a post-install step so we can specify the `--no-binary` option, which is not
-      # possible in a pip entry in the `python.install` section of this config file.
-      - python -m pip install '.[server,docs]' --no-binary lxml
-      # Experimental dependencies are not supported in standard package metadata, so we
-      # need to pip install them directly.
-      - python -m pip install -r requirements-experimental.txt
+      # Use job hooks so we can specify the `--no-binary` option, which is not
+      # possible in the `python.install` section of this config file.
+      - python -m pip install '.[server,docs]' --no-binary lxml --upgrade --upgrade-strategy only-if-needed
+      # Experimental dependencies are not supported in standard package
+      # metadata, so we need to pip install them directly.
+      - python -m pip install --exists-action=w -r requirements-experimental.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,17 +15,15 @@ build:
     - libssl-dev
     - openssl
     - libcurl4-openssl-dev
+  jobs:
+    pre_install:
+      # Use a pre-install step so we can specify the `--no-binary` option, which is
+      # not possible a pip entry in the `python.install` section of this config file.
+      - pip install '.[server,docs]' --no-binary lxml
 
 python:
   install:
-    # Install first to make sure the --no-binary option is used for html5-parser/lxml.
-    # (The option is not preserved when installing from the wayback package definition.)
-    - requirements: "requirements.txt"
-    - method: pip
-      path: "."
-      extra_requirements:
-        - server
-        - docs
+    # Also add experimental features.
     - requirements: "requirements-experimental.txt"
 
 sphinx:


### PR DESCRIPTION
Per discussion in https://github.com/readthedocs/readthedocs.org/issues/10789, ReadTheDocs doesn’t ever plan to support a way to set the `--no-binary` flag in a pip install step. However, there is a newer feature that allows us to specify pre/post install commands, so this is attempt to install that way instead.

Overall, the goal here is to get away from `requirements.txt` files and smooth a path towards `pyproject.toml` and other more modern tools.