### PR TITLE
Widen lxml support to include v6.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@
 beautifulsoup4 >=4.9.0,<5
 fast_diff_match_patch >=2.0.1,<3
 html5-parser >=0.4.0,<0.5 --no-binary lxml
-lxml >=4.5.0,<6
+lxml >=4.5.0,<7


### PR DESCRIPTION
I don’t believe there are any changes that should be breaking for us. Changelog: https://lxml.de/6.0/changes-6.0.0.html