### PR TITLE
Upgrade Sphinx to v8.2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   primary-python-version:
     type: string
-    default: "3.10.11"
+    default: "3.14"
 
 commands:
   setup_pip:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.14"
   apt_packages:
     - libxml2-dev
     - libxslt-dev

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,6 +11,6 @@
 # setup.py.
 ipython ~=7.34.0
 numpydoc ~=1.10
-sphinx ~=8.1.3
+sphinx ~=8.2.3
 sphinx-copybutton ~=0.5.2
 sphinx_rtd_theme ~=3.0.2


### PR DESCRIPTION
Update Sphinx to the latest version that sphinx-rtd-theme works with. Also build docs with current Python.