### PR TITLE
Add dogpile.cache response and diff result caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,25 @@ export DIFFER_MAX_BODY_SIZE='10485760' # 10 MB
 # Instead of crashing when the process pool used for running diffs breaks,
 # keep accepting requests and try to restart the pool.
 # RESTART_BROKEN_DIFFER='true'
+
+
+# Caching variables -------------------------------
+# Caching requires the [cache] extras to be installed:
+#   pip install "web-monitoring-diff[server,cache]"
+
+# Redis URL to use for caching HTTP responses and diff results.
+# When set, Redis is used as the cache backend; otherwise an in-memory cache
+# is used instead (data is lost on restart).
+# export CACHE_REDIS_URL="redis://localhost:6379/0"
+
+# How long a cached HTTP response body is considered fresh (seconds).
+# Defaults to 3600 (1 hour).
+# export CACHE_RESPONSE_EXPIRATION_SECONDS=3600
+
+# How long a cached diff result is considered fresh (seconds).
+# Defaults to 86400 (24 hours). Set to 0 to disable diff result caching.
+# export CACHE_DIFF_EXPIRATION_SECONDS=86400
+
+# Maximum number of items kept in the in-memory cache (ignored with Redis).
+# Defaults to 500.
+# export CACHE_MAX_SIZE=500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,13 @@ server = [
     "sentry-sdk[tornado] >=2.0.0,<3.0",
     "tornado >=6.0.0,<7",
 ]
+# Caching support (Redis + in-memory fallback via dogpile.cache).
+# hiredis is optional but strongly recommended for Redis performance.
+cache = [
+    "dogpile.cache >=1.3.0,<2",
+    "redis >=5.0,<6",
+    "hiredis >=3.0,<4",
+]
 # Development-related dependencies (for building, running tests, etc.)
 dev = [
     "coverage ~=7.13",

--- a/web_monitoring_diff/server/cache.py
+++ b/web_monitoring_diff/server/cache.py
@@ -1,0 +1,367 @@
+"""
+Caching support for the web-monitoring-diff server.
+
+Provides two separate caches: a response cache for storing raw HTTP
+response bodies, and a diff cache for storing serialized diff results.
+
+Both caches use dogpile.cache as the interface layer.
+
+Environment Variables
+---------------------
+CACHE_REDIS_URL : str
+    Full Redis connection URL, e.g. redis://localhost:6379/0.
+    When set, Redis is used as the cache backend.
+    If not set, an in-memory cache is used instead.
+
+CACHE_RESPONSE_EXPIRATION_SECONDS : int
+    How long a cached HTTP response is considered fresh, in seconds.
+    Defaults to 3600.
+
+CACHE_DIFF_EXPIRATION_SECONDS : int
+    How long a cached diff result is considered fresh, in seconds.
+    Defaults to 86400. Set to 0 to disable diff result caching.
+
+CACHE_MAX_SIZE : int
+    Maximum number of items stored in the in-memory backend.
+    Defaults to 500.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import pickle
+
+logger = logging.getLogger(__name__)
+
+# Configuration read from environment
+CACHE_REDIS_URL = os.environ.get('CACHE_REDIS_URL', '')
+CACHE_RESPONSE_EXPIRATION_SECONDS = int(
+    os.environ.get('CACHE_RESPONSE_EXPIRATION_SECONDS', 3600))
+CACHE_DIFF_EXPIRATION_SECONDS = int(
+    os.environ.get('CACHE_DIFF_EXPIRATION_SECONDS', 86400))
+CACHE_MAX_SIZE = int(os.environ.get('CACHE_MAX_SIZE', 500))
+
+
+def _require_dogpile():
+    """
+    Ensure the dogpile cache library is installed before proceeding.
+    """
+    try:
+        from dogpile.cache import make_region
+        return make_region
+    except ImportError as exc:
+        raise ImportError(
+            'dogpile.cache is required for server-side caching. '
+            'Install it with: pip install "web-monitoring-diff[cache]"'
+        ) from exc
+
+
+class CachedResponse:
+    """
+    Lightweight container holding an HTTP response for diffing.
+    
+    Parameters
+    ----------
+    url : str
+        The URL of the response.
+    body : bytes
+        The response body content.
+    headers : dict
+        A dictionary of HTTP headers.
+    """
+    __slots__ = ('url', 'body', 'headers')
+
+    def __init__(self, url, body, headers):
+        self.url = url
+        self.body = body
+        # Store headers as a plain dict so pickle round-trips cleanly.
+        self.headers = dict(headers) if headers else {}
+
+    # Duck-typing support to act like a Tornado HTTPResponse or MockResponse.
+    class _FakeRequest:
+        __slots__ = ('url',)
+        def __init__(self, url):
+            self.url = url
+
+    @property
+    def request(self):
+        return self._FakeRequest(self.url)
+
+
+def _serialize(value):
+    """Serialize a value to bytes for storage."""
+    return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def _deserialize(data):
+    """
+    Deserialize a value from bytes.
+    """
+    if data is None:
+        return None
+    return pickle.loads(data)
+
+
+def _make_redis_region(name, expiration_seconds):
+    """Build a dogpile.cache region backed by Redis."""
+    make_region = _require_dogpile()
+
+    backend_args = {'url': CACHE_REDIS_URL}
+
+    # Use hiredis if available for improved parsing performance.
+    try:
+        import hiredis  # noqa: F401
+        logger.debug('hiredis is available; Redis parsing will be accelerated.')
+    except ImportError:
+        logger.debug('hiredis not found; using pure-Python Redis parser.')
+
+    region = make_region(name=name).configure(
+        'dogpile.cache.redis',
+        expiration_time=expiration_seconds,
+        arguments=backend_args,
+    )
+    logger.info(
+        'Cache "%s" using Redis backend at %s (TTL %ds)',
+        name, CACHE_REDIS_URL, expiration_seconds,
+    )
+    return region
+
+
+def _make_memory_region(name, expiration_seconds):
+    """Build a dogpile.cache region backed by a simple in-memory dict."""
+    make_region = _require_dogpile()
+    region = make_region(name=name).configure(
+        'dogpile.cache.memory',
+        expiration_time=expiration_seconds,
+        arguments={'cache_size': CACHE_MAX_SIZE},
+    )
+    logger.info(
+        'Cache "%s" using in-memory backend (max size %d, TTL %ds)',
+        name, CACHE_MAX_SIZE, expiration_seconds,
+    )
+    return region
+
+
+def _make_region(name, expiration_seconds):
+    """Return an appropriate dogpile.cache region for the current config."""
+    if CACHE_REDIS_URL:
+        try:
+            return _make_redis_region(name, expiration_seconds)
+        except Exception as exc:
+            logger.warning(
+                'Failed to connect to Redis (%s). '
+                'Falling back to in-memory cache for "%s".',
+                exc, name,
+            )
+    return _make_memory_region(name, expiration_seconds)
+
+
+# Module-level singletons; created lazily so that import doesn't fail when
+# dogpile.cache is not installed.
+_response_region = None
+_diff_region = None
+
+
+def _get_response_region():
+    """Retrieve the global response cache region, creating it if necessary."""
+    global _response_region
+    if _response_region is None:
+        _response_region = _make_region(
+            'responses', CACHE_RESPONSE_EXPIRATION_SECONDS)
+    return _response_region
+
+
+def _get_diff_region():
+    """Retrieve the global diff cache region, creating it if necessary."""
+    global _diff_region
+    if _diff_region is None:
+        _diff_region = _make_region(
+            'diffs', CACHE_DIFF_EXPIRATION_SECONDS)
+    return _diff_region
+
+
+def make_response_cache_key(url):
+    """
+    Create a stable cache key for a fetched HTTP response.
+    
+    Parameters
+    ----------
+    url : str
+        The URL that was fetched.
+        
+    Returns
+    -------
+    str
+        A unique string key using the SHA-256 hex digest of the URL.
+    """
+    return 'response:' + hashlib.sha256(url.encode()).hexdigest()
+
+
+def make_diff_cache_key(differ_name, a_url, b_url, extra_params):
+    """
+    Create a stable cache key for a diff result.
+    
+    Parameters
+    ----------
+    differ_name : str
+        The name of the type of diff performed.
+    a_url : str
+        Target URL a.
+    b_url : str
+        Target URL b.
+    extra_params : dict
+        Additional query parameters.
+        
+    Returns
+    -------
+    str
+        A unique string key using the SHA-256 hex digest of the inputs.
+    """
+    params_repr = json.dumps(extra_params, sort_keys=True)
+    key_data = f'{differ_name}\x00{a_url}\x00{b_url}\x00{params_repr}'
+    return 'diff:' + hashlib.sha256(key_data.encode()).hexdigest()
+
+
+def get_cached_response(url):
+    """
+    Retrieve a cached response for the given URL.
+    
+    Parameters
+    ----------
+    url : str
+        The URL to check the cache for.
+        
+    Returns
+    -------
+    CachedResponse or None
+        The cached HTTP response, or None if not found or if caching is disabled.
+    """
+    try:
+        region = _get_response_region()
+        key = make_response_cache_key(url)
+        raw = region.get(key)
+        if raw is None:
+            return None
+        # dogpile.cache uses a sentinel NO_VALUE object; check for it.
+        from dogpile.cache.api import NO_VALUE
+        if raw is NO_VALUE:
+            return None
+        value = _deserialize(raw)
+        logger.debug('Response cache HIT for %s', url)
+        return value
+    except Exception:
+        logger.exception('Error reading from response cache for %s', url)
+        return None
+
+
+def cache_response(url, response):
+    """
+    Store an HTTP response in the cache for a given URL.
+    
+    Errors are silently ignored so that cache failures never break a request.
+    
+    Parameters
+    ----------
+    url : str
+        The URL corresponding to the response.
+    response : HTTPResponse or MockResponse
+        The response object to serialize and cache.
+    """
+    try:
+        region = _get_response_region()
+        key = make_response_cache_key(url)
+        cached = CachedResponse(
+            url=url,
+            body=response.body,
+            headers=response.headers,
+        )
+        region.set(key, _serialize(cached))
+        logger.debug('Response cache SET for %s', url)
+    except Exception:
+        logger.exception('Error writing to response cache for %s', url)
+
+
+def get_cached_diff(differ_name, a_url, b_url, extra_params):
+    """
+    Retrieve a cached diff result for the given inputs.
+    
+    Parameters
+    ----------
+    differ_name : str
+        The name of the type of diff performed.
+    a_url : str
+        Target URL a.
+    b_url : str
+        Target URL b.
+    extra_params : dict
+        Additional query parameters.
+        
+    Returns
+    -------
+    dict or None
+        The cached JSON-serializable diff payload, or None if not found.
+    """
+    if CACHE_DIFF_EXPIRATION_SECONDS == 0:
+        return None
+    try:
+        region = _get_diff_region()
+        key = make_diff_cache_key(differ_name, a_url, b_url, extra_params)
+        raw = region.get(key)
+        if raw is None:
+            return None
+        from dogpile.cache.api import NO_VALUE
+        if raw is NO_VALUE:
+            return None
+        value = _deserialize(raw)
+        logger.debug('Diff cache HIT for %s(%s, %s)', differ_name, a_url, b_url)
+        return value
+    except Exception:
+        logger.exception('Error reading from diff cache')
+        return None
+
+
+def cache_diff(differ_name, a_url, b_url, extra_params, result):
+    """
+    Store a computed diff result in the cache.
+    
+    Errors are silently ignored.
+    
+    Parameters
+    ----------
+    differ_name : str
+        The name of the type of diff performed.
+    a_url : str
+        Target URL a.
+    b_url : str
+        Target URL b.
+    extra_params : dict
+        Additional query parameters.
+    result : dict
+        The JSON-serializable payload produced by the differ function.
+    """
+    if CACHE_DIFF_EXPIRATION_SECONDS == 0:
+        return
+    try:
+        region = _get_diff_region()
+        key = make_diff_cache_key(differ_name, a_url, b_url, extra_params)
+        region.set(key, _serialize(result))
+        logger.debug('Diff cache SET for %s(%s, %s)', differ_name, a_url, b_url)
+    except Exception:
+        logger.exception('Error writing to diff cache')
+
+
+def is_caching_enabled():
+    """
+    Check if the caching library dependency is met.
+    
+    Returns
+    -------
+    bool
+        True when dogpile.cache is globally importable.
+    """
+    try:
+        import dogpile.cache  # noqa: F401
+        return True
+    except ImportError:
+        return False

--- a/web_monitoring_diff/server/cache.py
+++ b/web_monitoring_diff/server/cache.py
@@ -1,29 +1,34 @@
 """
 Caching support for the web-monitoring-diff server.
 
-Provides two separate caches: a response cache for storing raw HTTP
-response bodies, and a diff cache for storing serialized diff results.
+Two separate caches are provided:
 
-Both caches use dogpile.cache as the interface layer.
+* A response cache that stores the raw HTTP response body and headers
+  for a given URL. This avoids repeated upstream fetches when the same
+  URL appears across successive diff requests (e.g. a user switching
+  between differ types, or comparing capture X→Y then X→Z).
 
-Environment Variables
+* A diff cache that stores the serialized result of a completed diff
+  keyed on the differ name, both URLs, and any extra query parameters.
+
+Both caches use dogpile.cache as the underlying interface, which
+supports pluggable backends.  Redis is used when ``CACHE_REDIS_URL``
+is set in the environment; otherwise a simple in-memory dict is used
+as a fallback.
+
+Environment variables
 ---------------------
-CACHE_REDIS_URL : str
-    Full Redis connection URL, e.g. redis://localhost:6379/0.
-    When set, Redis is used as the cache backend.
-    If not set, an in-memory cache is used instead.
-
-CACHE_RESPONSE_EXPIRATION_SECONDS : int
-    How long a cached HTTP response is considered fresh, in seconds.
-    Defaults to 3600.
-
-CACHE_DIFF_EXPIRATION_SECONDS : int
-    How long a cached diff result is considered fresh, in seconds.
-    Defaults to 86400. Set to 0 to disable diff result caching.
-
-CACHE_MAX_SIZE : int
-    Maximum number of items stored in the in-memory backend.
-    Defaults to 500.
+CACHE_REDIS_URL
+    Full Redis connection URL, e.g. ``redis://localhost:6379/0``.
+    When not set, an in-memory cache is used instead.
+CACHE_RESPONSE_EXPIRATION_SECONDS
+    TTL for cached HTTP responses, in seconds (default: 3600).
+CACHE_DIFF_EXPIRATION_SECONDS
+    TTL for cached diff results, in seconds (default: 86400).
+    Set to 0 to disable diff result caching entirely.
+CACHE_MAX_SIZE
+    Maximum number of entries in the in-memory backend (default: 500).
+    Ignored when Redis is used.
 """
 
 import hashlib
@@ -34,19 +39,13 @@ import pickle
 
 logger = logging.getLogger(__name__)
 
-# Configuration read from environment
 CACHE_REDIS_URL = os.environ.get('CACHE_REDIS_URL', '')
-CACHE_RESPONSE_EXPIRATION_SECONDS = int(
-    os.environ.get('CACHE_RESPONSE_EXPIRATION_SECONDS', 3600))
-CACHE_DIFF_EXPIRATION_SECONDS = int(
-    os.environ.get('CACHE_DIFF_EXPIRATION_SECONDS', 86400))
+CACHE_RESPONSE_EXPIRATION_SECONDS = int(os.environ.get('CACHE_RESPONSE_EXPIRATION_SECONDS', 3600))
+CACHE_DIFF_EXPIRATION_SECONDS = int(os.environ.get('CACHE_DIFF_EXPIRATION_SECONDS', 86400))
 CACHE_MAX_SIZE = int(os.environ.get('CACHE_MAX_SIZE', 500))
 
 
 def _require_dogpile():
-    """
-    Ensure the dogpile cache library is installed before proceeding.
-    """
     try:
         from dogpile.cache import make_region
         return make_region
@@ -58,17 +57,11 @@ def _require_dogpile():
 
 
 class CachedResponse:
-    """
-    Lightweight container holding an HTTP response for diffing.
-    
-    Parameters
-    ----------
-    url : str
-        The URL of the response.
-    body : bytes
-        The response body content.
-    headers : dict
-        A dictionary of HTTP headers.
+    """A lightweight stand-in for a Tornado HTTPResponse.
+
+    Stores only the parts of a response that the server actually needs for
+    diffing (URL, body, headers) and exposes the same ``.request.url``
+    attribute that the rest of the server code depends on.
     """
     __slots__ = ('url', 'body', 'headers')
 
@@ -78,7 +71,6 @@ class CachedResponse:
         # Store headers as a plain dict so pickle round-trips cleanly.
         self.headers = dict(headers) if headers else {}
 
-    # Duck-typing support to act like a Tornado HTTPResponse or MockResponse.
     class _FakeRequest:
         __slots__ = ('url',)
         def __init__(self, url):
@@ -90,276 +82,149 @@ class CachedResponse:
 
 
 def _serialize(value):
-    """Serialize a value to bytes for storage."""
     return pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
 
 
 def _deserialize(data):
-    """
-    Deserialize a value from bytes.
-    """
-    if data is None:
-        return None
-    return pickle.loads(data)
+    return pickle.loads(data) if data is not None else None
 
 
-def _make_redis_region(name, expiration_seconds):
-    """Build a dogpile.cache region backed by Redis."""
+def _make_region(name, expiration_seconds):
+    """Configure and return a dogpile.cache region.
+
+    Tries Redis first (when ``CACHE_REDIS_URL`` is set), and falls back to
+    the in-memory backend if the connection fails.
+    """
     make_region = _require_dogpile()
 
-    backend_args = {'url': CACHE_REDIS_URL}
+    if CACHE_REDIS_URL:
+        try:
+            # redis-py automatically uses hiredis when it is importable, giving
+            # a significant parsing speedup with no extra configuration needed.
+            try:
+                import hiredis  # noqa: F401
+                logger.debug('hiredis is available; Redis parsing will be accelerated.')
+            except ImportError:
+                logger.debug('hiredis not found; using pure-Python Redis parser.')
 
-    # Use hiredis if available for improved parsing performance.
-    try:
-        import hiredis  # noqa: F401
-        logger.debug('hiredis is available; Redis parsing will be accelerated.')
-    except ImportError:
-        logger.debug('hiredis not found; using pure-Python Redis parser.')
+            region = make_region(name=name).configure(
+                'dogpile.cache.redis',
+                expiration_time=expiration_seconds,
+                arguments={'url': CACHE_REDIS_URL},
+            )
+            logger.info('Cache "%s" using Redis backend at %s (TTL %ds)',
+                        name, CACHE_REDIS_URL, expiration_seconds)
+            return region
+        except Exception as exc:
+            logger.warning('Failed to connect to Redis (%s); falling back to in-memory cache for "%s".',
+                           exc, name)
 
-    region = make_region(name=name).configure(
-        'dogpile.cache.redis',
-        expiration_time=expiration_seconds,
-        arguments=backend_args,
-    )
-    logger.info(
-        'Cache "%s" using Redis backend at %s (TTL %ds)',
-        name, CACHE_REDIS_URL, expiration_seconds,
-    )
-    return region
-
-
-def _make_memory_region(name, expiration_seconds):
-    """Build a dogpile.cache region backed by a simple in-memory dict."""
-    make_region = _require_dogpile()
     region = make_region(name=name).configure(
         'dogpile.cache.memory',
         expiration_time=expiration_seconds,
         arguments={'cache_size': CACHE_MAX_SIZE},
     )
-    logger.info(
-        'Cache "%s" using in-memory backend (max size %d, TTL %ds)',
-        name, CACHE_MAX_SIZE, expiration_seconds,
-    )
+    logger.info('Cache "%s" using in-memory backend (max size %d, TTL %ds)',
+                name, CACHE_MAX_SIZE, expiration_seconds)
     return region
 
 
-def _make_region(name, expiration_seconds):
-    """Return an appropriate dogpile.cache region for the current config."""
-    if CACHE_REDIS_URL:
-        try:
-            return _make_redis_region(name, expiration_seconds)
-        except Exception as exc:
-            logger.warning(
-                'Failed to connect to Redis (%s). '
-                'Falling back to in-memory cache for "%s".',
-                exc, name,
-            )
-    return _make_memory_region(name, expiration_seconds)
+# Lazily-created singletons so importing this module doesn't fail when
+# dogpile.cache isn't installed.
+_regions = {}
 
 
-# Module-level singletons; created lazily so that import doesn't fail when
-# dogpile.cache is not installed.
-_response_region = None
-_diff_region = None
+def _get_region(name, expiration_seconds):
+    if name not in _regions:
+        _regions[name] = _make_region(name, expiration_seconds)
+    return _regions[name]
 
 
+# Thin wrappers used as interception points in tests.
 def _get_response_region():
-    """Retrieve the global response cache region, creating it if necessary."""
-    global _response_region
-    if _response_region is None:
-        _response_region = _make_region(
-            'responses', CACHE_RESPONSE_EXPIRATION_SECONDS)
-    return _response_region
+    return _get_region('responses', CACHE_RESPONSE_EXPIRATION_SECONDS)
 
 
 def _get_diff_region():
-    """Retrieve the global diff cache region, creating it if necessary."""
-    global _diff_region
-    if _diff_region is None:
-        _diff_region = _make_region(
-            'diffs', CACHE_DIFF_EXPIRATION_SECONDS)
-    return _diff_region
+    return _get_region('diffs', CACHE_DIFF_EXPIRATION_SECONDS)
 
 
+def _cache_get(region_getter, key, label):
+    """Try to read *key* from the region returned by *region_getter*.
+
+    Returns the deserialized value on a hit, or ``None`` on a miss or error.
+    Cache errors are always logged and swallowed so they never break a request.
+    """
+    try:
+        raw = region_getter().get(key)
+        if raw is None:
+            return None
+        from dogpile.cache.api import NO_VALUE
+        if raw is NO_VALUE:
+            return None
+        logger.debug('%s cache HIT for %s', label, key)
+        return _deserialize(raw)
+    except Exception:
+        logger.exception('Error reading from %s cache', label.lower())
+        return None
+
+
+def _cache_set(region_getter, key, value, label):
+    """Try to write *value* to the region returned by *region_getter*.
+
+    Errors are logged and swallowed so they never break a request.
+    """
+    try:
+        region_getter().set(key, _serialize(value))
+        logger.debug('%s cache SET for %s', label, key)
+    except Exception:
+        logger.exception('Error writing to %s cache', label.lower())
+
+
+# Public API
 def make_response_cache_key(url):
-    """
-    Create a stable cache key for a fetched HTTP response.
-    
-    Parameters
-    ----------
-    url : str
-        The URL that was fetched.
-        
-    Returns
-    -------
-    str
-        A unique string key using the SHA-256 hex digest of the URL.
-    """
+    "Return the cache key for a given URL's response."
     return 'response:' + hashlib.sha256(url.encode()).hexdigest()
 
 
 def make_diff_cache_key(differ_name, a_url, b_url, extra_params):
-    """
-    Create a stable cache key for a diff result.
-    
-    Parameters
-    ----------
-    differ_name : str
-        The name of the type of diff performed.
-    a_url : str
-        Target URL a.
-    b_url : str
-        Target URL b.
-    extra_params : dict
-        Additional query parameters.
-        
-    Returns
-    -------
-    str
-        A unique string key using the SHA-256 hex digest of the inputs.
-    """
+    "Return the cache key for a given diff configuration."
     params_repr = json.dumps(extra_params, sort_keys=True)
     key_data = f'{differ_name}\x00{a_url}\x00{b_url}\x00{params_repr}'
     return 'diff:' + hashlib.sha256(key_data.encode()).hexdigest()
 
 
 def get_cached_response(url):
-    """
-    Retrieve a cached response for the given URL.
-    
-    Parameters
-    ----------
-    url : str
-        The URL to check the cache for.
-        
-    Returns
-    -------
-    CachedResponse or None
-        The cached HTTP response, or None if not found or if caching is disabled.
-    """
-    try:
-        region = _get_response_region()
-        key = make_response_cache_key(url)
-        raw = region.get(key)
-        if raw is None:
-            return None
-        # dogpile.cache uses a sentinel NO_VALUE object; check for it.
-        from dogpile.cache.api import NO_VALUE
-        if raw is NO_VALUE:
-            return None
-        value = _deserialize(raw)
-        logger.debug('Response cache HIT for %s', url)
-        return value
-    except Exception:
-        logger.exception('Error reading from response cache for %s', url)
-        return None
+    "Return a cached CachedResponse for *url*, or None on a miss."
+    return _cache_get(_get_response_region, make_response_cache_key(url), 'Response')
 
 
 def cache_response(url, response):
-    """
-    Store an HTTP response in the cache for a given URL.
-    
-    Errors are silently ignored so that cache failures never break a request.
-    
-    Parameters
-    ----------
-    url : str
-        The URL corresponding to the response.
-    response : HTTPResponse or MockResponse
-        The response object to serialize and cache.
-    """
-    try:
-        region = _get_response_region()
-        key = make_response_cache_key(url)
-        cached = CachedResponse(
-            url=url,
-            body=response.body,
-            headers=response.headers,
-        )
-        region.set(key, _serialize(cached))
-        logger.debug('Response cache SET for %s', url)
-    except Exception:
-        logger.exception('Error writing to response cache for %s', url)
+    "Store an HTTP response body and headers in the response cache."
+    cached = CachedResponse(url=url, body=response.body, headers=response.headers)
+    _cache_set(_get_response_region, make_response_cache_key(url), cached, 'Response')
 
 
 def get_cached_diff(differ_name, a_url, b_url, extra_params):
-    """
-    Retrieve a cached diff result for the given inputs.
-    
-    Parameters
-    ----------
-    differ_name : str
-        The name of the type of diff performed.
-    a_url : str
-        Target URL a.
-    b_url : str
-        Target URL b.
-    extra_params : dict
-        Additional query parameters.
-        
-    Returns
-    -------
-    dict or None
-        The cached JSON-serializable diff payload, or None if not found.
-    """
+    "Return a cached diff result dict for the given inputs, or None on a miss."
     if CACHE_DIFF_EXPIRATION_SECONDS == 0:
         return None
-    try:
-        region = _get_diff_region()
-        key = make_diff_cache_key(differ_name, a_url, b_url, extra_params)
-        raw = region.get(key)
-        if raw is None:
-            return None
-        from dogpile.cache.api import NO_VALUE
-        if raw is NO_VALUE:
-            return None
-        value = _deserialize(raw)
-        logger.debug('Diff cache HIT for %s(%s, %s)', differ_name, a_url, b_url)
-        return value
-    except Exception:
-        logger.exception('Error reading from diff cache')
-        return None
+    return _cache_get(_get_diff_region,
+                      make_diff_cache_key(differ_name, a_url, b_url, extra_params),
+                      'Diff')
 
 
 def cache_diff(differ_name, a_url, b_url, extra_params, result):
-    """
-    Store a computed diff result in the cache.
-    
-    Errors are silently ignored.
-    
-    Parameters
-    ----------
-    differ_name : str
-        The name of the type of diff performed.
-    a_url : str
-        Target URL a.
-    b_url : str
-        Target URL b.
-    extra_params : dict
-        Additional query parameters.
-    result : dict
-        The JSON-serializable payload produced by the differ function.
-    """
+    "Store a diff result dict in the diff cache."
     if CACHE_DIFF_EXPIRATION_SECONDS == 0:
         return
-    try:
-        region = _get_diff_region()
-        key = make_diff_cache_key(differ_name, a_url, b_url, extra_params)
-        region.set(key, _serialize(result))
-        logger.debug('Diff cache SET for %s(%s, %s)', differ_name, a_url, b_url)
-    except Exception:
-        logger.exception('Error writing to diff cache')
+    _cache_set(_get_diff_region,
+               make_diff_cache_key(differ_name, a_url, b_url, extra_params),
+               result, 'Diff')
 
 
 def is_caching_enabled():
-    """
-    Check if the caching library dependency is met.
-    
-    Returns
-    -------
-    bool
-        True when dogpile.cache is globally importable.
-    """
+    "Return True if dogpile.cache is installed."
     try:
         import dogpile.cache  # noqa: F401
         return True

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -20,6 +20,12 @@ import tornado.web
 import traceback
 import web_monitoring_diff
 from .mock_http import MockResponse
+from .cache import (
+    get_cached_response,
+    cache_response,
+    get_cached_diff,
+    cache_diff,
+)
 from .. import basic_diffs, html_render_diff, html_links_diff
 from ..exceptions import UndiffableContentError, UndecodableContentError
 from ..utils import shutdown_executor_in_loop, Signal
@@ -320,24 +326,59 @@ class DiffHandler(BaseHandler):
                               'as the value for both `a` and `b` query '
                               'parameters.')
 
-        # TODO: Add caching of fetched URIs.
+        a_url = urls['a']
+        b_url = urls['b']
+
+        # Pop the per-URL hash params before building the diff cache key so
+        # they don't affect the key (the hash is used for validation, not
+        # content identity).
+        a_hash = query_params.pop('a_hash', None)
+        b_hash = query_params.pop('b_hash', None)
+
+        # Diff-result caching only applies to HTTP/HTTPS URLs. file:// URLs are
+        # development-only and their content can change without notice, so we
+        # skip caching for them.
+        _http_schemes = ('http://', 'https://')
+        use_diff_cache = (a_url.startswith(_http_schemes)
+                          and b_url.startswith(_http_schemes))
+
+        # --- Diff result cache (check before fetching upstream content) -----
+        if use_diff_cache:
+            cached_result = get_cached_diff(differ, a_url, b_url, query_params)
+            if cached_result is not None:
+                cached_result['version'] = web_monitoring_diff.__version__
+                cached_result.setdefault('type', differ)
+                self.write(cached_result)
+                return
+
+        # Fetch both URLs, using the per-URL response cache where possible.
         requests = [self.fetch_diffable_content(url,
-                                                query_params.pop(f'{param}_hash', None),
+                                                hash_val,
                                                 query_params)
-                    for param, url in urls.items()]
+                    for (param, url), hash_val
+                    in zip(urls.items(), (a_hash, b_hash))]
         content = await asyncio.gather(*requests)
 
         # Pass the bytes and any remaining args to the diffing function.
         res = await self.diff(func, content[0], content[1], query_params)
+
+        # Store the diff result for future requests (HTTP/HTTPS only).
+        if use_diff_cache:
+            cache_diff(differ, a_url, b_url, query_params, res)
+
         res['version'] = web_monitoring_diff.__version__
         # Echo the client's request unless the differ func has specified
-        # somethine else.
+        # something else.
         res.setdefault('type', differ)
         self.write(res)
 
     async def fetch_diffable_content(self, url, expected_hash, query_params):
         """
         Fetch and validate a content to diff from a given URL.
+
+        For HTTP/HTTPS URLs the response body and headers are cached so that
+        repeated requests for the same URL (e.g. when a user switches between
+        diff types) can be served without a new upstream request.
         """
         response = None
 
@@ -357,6 +398,12 @@ class DiffHandler(BaseHandler):
                               'Invalid URL for upstream content',
                               extra={'url': url})
         else:
+            # --- Response cache: serve from cache when available ------------
+            cached = get_cached_response(url)
+            if cached is not None:
+                # Skip hash validation for cached content: the hash was
+                # already verified when the response was first stored.
+                return cached
             # Include request headers defined by the query param
             # `pass_headers=HEADER_NAMES` in the upstream request. This is
             # useful for passing data like cookie headers. HEADER_NAMES is a
@@ -472,6 +519,11 @@ class DiffHandler(BaseHandler):
                                          'url': url,
                                          'expected_hash': expected_hash,
                                          'actual_hash': actual_hash})
+
+        # Store a freshly-fetched HTTP/HTTPS response in the cache so
+        # subsequent requests for the same URL are served faster.
+        if response is not None and url.startswith(('http://', 'https://')):
+            cache_response(url, response)
 
         return response
 

--- a/web_monitoring_diff/tests/test_server_caching.py
+++ b/web_monitoring_diff/tests/test_server_caching.py
@@ -1,0 +1,394 @@
+"""
+Tests for the server caching layer (web_monitoring_diff.server.cache).
+
+These tests exercise the cache module in isolation using dogpile.cache's
+in-memory backend, so no Redis instance is required.  They also include
+integration-style tests that verify the full server request path hits the
+cache correctly.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from tornado.testing import AsyncHTTPTestCase
+
+import web_monitoring_diff.server.server as df
+from web_monitoring_diff.server import cache as cache_module
+from web_monitoring_diff.server.cache import (
+    CachedResponse,
+    make_response_cache_key,
+    make_diff_cache_key,
+    _serialize,
+    _deserialize,
+)
+from web_monitoring_diff.server.mock_http import MockResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by unit and integration tests
+# ---------------------------------------------------------------------------
+
+def fixture_path(name):
+    return Path(__file__).resolve().parent / 'fixtures' / name
+
+
+def _make_memory_region(expiration=60):
+    """
+    Return a fresh dogpile.cache in-memory region for testing.
+    """
+    from dogpile.cache import make_region
+    return make_region().configure(
+        'dogpile.cache.memory',
+        expiration_time=expiration,
+        arguments={'cache_size': 100},
+    )
+
+
+def _mock_region():
+    """
+    Return a simple dict-backed fake region (no dogpile.cache required).
+    """
+    class _FakeRegion:
+        def __init__(self):
+            self._store = {}
+
+        def get(self, key):
+            from dogpile.cache.api import NO_VALUE
+            return self._store.get(key, NO_VALUE)
+
+        def set(self, key, value):
+            self._store[key] = value
+
+    return _FakeRegion()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – cache module in isolation
+# ---------------------------------------------------------------------------
+
+class TestCacheKeys(unittest.TestCase):
+    def test_response_key_is_stable(self):
+        url = 'https://example.org/page'
+        assert make_response_cache_key(url) == make_response_cache_key(url)
+
+    def test_response_key_differs_for_different_urls(self):
+        assert (make_response_cache_key('https://a.org')
+                != make_response_cache_key('https://b.org'))
+
+    def test_response_key_has_prefix(self):
+        key = make_response_cache_key('https://example.org')
+        assert key.startswith('response:')
+
+    def test_diff_key_is_stable(self):
+        params = {'format': 'json', 'include': 'all'}
+        k1 = make_diff_cache_key('html_token', 'http://a', 'http://b', params)
+        k2 = make_diff_cache_key('html_token', 'http://a', 'http://b', params)
+        assert k1 == k2
+
+    def test_diff_key_differs_for_different_differs(self):
+        params = {}
+        k1 = make_diff_cache_key('html_token', 'http://a', 'http://b', params)
+        k2 = make_diff_cache_key('html_source_dmp', 'http://a', 'http://b', params)
+        assert k1 != k2
+
+    def test_diff_key_differs_for_different_urls(self):
+        params = {}
+        k1 = make_diff_cache_key('html_token', 'http://a', 'http://b', params)
+        k2 = make_diff_cache_key('html_token', 'http://a', 'http://c', params)
+        assert k1 != k2
+
+    def test_diff_key_params_order_independent(self):
+        """Extra params must produce the same key regardless of dict order."""
+        k1 = make_diff_cache_key('d', 'a', 'b', {'x': '1', 'y': '2'})
+        k2 = make_diff_cache_key('d', 'a', 'b', {'y': '2', 'x': '1'})
+        assert k1 == k2
+
+    def test_diff_key_has_prefix(self):
+        key = make_diff_cache_key('d', 'a', 'b', {})
+        assert key.startswith('diff:')
+
+
+class TestCachedResponse(unittest.TestCase):
+    def test_body_and_headers_round_trip(self):
+        body = b'<html>hello</html>'
+        headers = {'Content-Type': 'text/html', 'X-Custom': 'value'}
+        resp = CachedResponse('https://example.org', body, headers)
+        assert resp.body == body
+        assert resp.headers == headers
+
+    def test_url_accessible_via_request_property(self):
+        resp = CachedResponse('https://example.org', b'', {})
+        assert resp.request.url == 'https://example.org'
+
+    def test_serialization_round_trip(self):
+        resp = CachedResponse('https://example.org', b'hello', {'CT': 'text/plain'})
+        data = _serialize(resp)
+        restored = _deserialize(data)
+        assert restored.url == resp.url
+        assert restored.body == resp.body
+        assert restored.headers == resp.headers
+
+
+class TestGetCacheResponse(unittest.TestCase):
+    """
+    Tests for get_cached_response / cache_response using patched regions.
+    """
+
+    def setUp(self):
+        # Reset module-level singletons before each test.
+        cache_module._response_region = None
+        cache_module._diff_region = None
+
+    def test_miss_returns_none(self):
+        region = _mock_region()
+        with patch.object(cache_module, '_get_response_region', return_value=region):
+            result = cache_module.get_cached_response('https://example.org/miss')
+        assert result is None
+
+    def test_hit_returns_cached_response(self):
+        region = _mock_region()
+        url = 'https://example.org/hit'
+        original = CachedResponse(url, b'data', {'CT': 'text/html'})
+        region.set(make_response_cache_key(url), _serialize(original))
+
+        with patch.object(cache_module, '_get_response_region', return_value=region):
+            result = cache_module.get_cached_response(url)
+
+        assert result is not None
+        assert result.body == b'data'
+
+    def test_cache_response_stores_value(self):
+        region = _mock_region()
+        url = 'https://example.org/store'
+        mock_resp = MockResponse(url, b'<html>test</html>')
+
+        with patch.object(cache_module, '_get_response_region', return_value=region):
+            cache_module.cache_response(url, mock_resp)
+            result = cache_module.get_cached_response(url)
+
+        assert result is not None
+        assert result.body == b'<html>test</html>'
+
+    def test_error_in_region_is_silenced(self):
+        """
+        Cache errors should never propagate to the caller.
+        """
+        broken_region = MagicMock()
+        broken_region.get.side_effect = RuntimeError('Redis is down')
+
+        with patch.object(cache_module, '_get_response_region', return_value=broken_region):
+            result = cache_module.get_cached_response('https://example.org')
+        # Should return None, not raise.
+        assert result is None
+
+    def test_cache_response_error_is_silenced(self):
+        broken_region = MagicMock()
+        broken_region.set.side_effect = RuntimeError('Redis is down')
+        mock_resp = MockResponse('https://example.org', b'data')
+
+        with patch.object(cache_module, '_get_response_region', return_value=broken_region):
+            # Should not raise.
+            cache_module.cache_response('https://example.org', mock_resp)
+
+
+class TestDiffCache(unittest.TestCase):
+    def setUp(self):
+        cache_module._response_region = None
+        cache_module._diff_region = None
+
+    def test_miss_returns_none(self):
+        region = _mock_region()
+        with patch.object(cache_module, '_get_diff_region', return_value=region):
+            result = cache_module.get_cached_diff('d', 'a', 'b', {})
+        assert result is None
+
+    def test_hit_returns_result(self):
+        region = _mock_region()
+        diff_result = {'change_count': 3, 'diff': []}
+        key = make_diff_cache_key('html_token', 'http://a', 'http://b', {})
+        region.set(key, _serialize(diff_result))
+
+        with patch.object(cache_module, '_get_diff_region', return_value=region):
+            result = cache_module.get_cached_diff('html_token', 'http://a', 'http://b', {})
+
+        assert result == diff_result
+
+    def test_cache_diff_stores_value(self):
+        region = _mock_region()
+        diff_result = {'change_count': 0}
+
+        with patch.object(cache_module, '_get_diff_region', return_value=region):
+            cache_module.cache_diff('d', 'a', 'b', {}, diff_result)
+            result = cache_module.get_cached_diff('d', 'a', 'b', {})
+
+        assert result == diff_result
+
+    def test_diff_cache_disabled_when_expiration_is_zero(self):
+        """Setting CACHE_DIFF_EXPIRATION_SECONDS=0 disables diff caching."""
+        with patch.object(cache_module, 'CACHE_DIFF_EXPIRATION_SECONDS', 0):
+            region = _mock_region()
+            with patch.object(cache_module, '_get_diff_region', return_value=region):
+                cache_module.cache_diff('d', 'a', 'b', {}, {'x': 1})
+                result = cache_module.get_cached_diff('d', 'a', 'b', {})
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – server endpoints hit the caches
+# ---------------------------------------------------------------------------
+
+def mock_http_client_decorator(test_func):
+    """
+    Replaces the server's HTTP client with a MockAsyncHttpClient (re-use the
+    helper already defined in test_server_exc_handling.py).
+    """
+    import re
+    from io import BytesIO
+    from tornado.httpclient import HTTPResponse, AsyncHTTPClient
+    from tornado.httputil import HTTPHeaders
+
+    class SimpleMockClient(AsyncHTTPClient):
+        def __init__(self):
+            self.call_count = 0
+            self._responses = {}
+
+        def respond_to(self, url_pattern, body=b'<html>test</html>', code=200):
+            self._responses[url_pattern] = (code, body)
+
+        def fetch_impl(self, request, callback):
+            self.call_count += 1
+            for pattern, (code, body) in self._responses.items():
+                if re.search(pattern, request.url):
+                    buf = BytesIO(body)
+                    headers = HTTPHeaders({'Content-Type': 'text/html'})
+                    callback(HTTPResponse(request, code, buffer=buf, headers=headers))
+                    return
+            raise ValueError(f'No stub for {request.url}')
+
+    def wrapper(self_, *args, **kwargs):
+        mock = SimpleMockClient()
+        with patch.object(df, 'get_http_client', return_value=mock):
+            return test_func(self_, mock, *args, **kwargs)
+
+    return wrapper
+
+
+class DiffServerCachingIntegrationTest(AsyncHTTPTestCase):
+
+    def get_app(self):
+        return df.make_app()
+
+    def setUp(self):
+        super().setUp()
+        # Reset module-level cache region singletons so each test starts fresh.
+        cache_module._response_region = None
+        cache_module._diff_region = None
+
+    def _make_memory_region_for_test(self, expiration=3600):
+        from dogpile.cache import make_region
+        return make_region().configure(
+            'dogpile.cache.memory',
+            expiration_time=expiration,
+            arguments={'cache_size': 200},
+        )
+
+    @mock_http_client_decorator
+    def test_response_cache_prevents_second_upstream_fetch(self, mock_client):
+        """
+        When the same URL appears in two successive diff requests (e.g. a user
+        switching from html_token to html_source_dmp), the upstream server
+        should only be contacted once.
+        """
+        url_a = 'https://example.org/page-a'
+        url_b = 'https://example.org/page-b'
+        mock_client.respond_to(r'page-a', body=b'<html>A</html>')
+        mock_client.respond_to(r'page-b', body=b'<html>B</html>')
+
+        region = self._make_memory_region_for_test()
+        with patch.object(cache_module, '_get_response_region', return_value=region), \
+             patch.object(cache_module, '_get_diff_region',
+                          return_value=self._make_memory_region_for_test()):
+
+            # First request – fetches both URLs.
+            r1 = self.fetch(f'/identical_bytes?a={url_a}&b={url_b}')
+            assert r1.code == 200
+            calls_after_first = mock_client.call_count
+            assert calls_after_first == 2  # both URLs fetched
+
+            # Second request with same URLs – should serve from response cache.
+            r2 = self.fetch(f'/html_source_dmp?a={url_a}&b={url_b}')
+            assert r2.code == 200
+            assert mock_client.call_count == calls_after_first  # no new upstream calls
+
+    @mock_http_client_decorator
+    def test_diff_cache_prevents_second_diff_computation(self, mock_client):
+        """
+        Identical diff requests should return the cached result without
+        re-running the diff function.
+        """
+        url_a = 'https://example.org/page-a'
+        url_b = 'https://example.org/page-b'
+        mock_client.respond_to(r'page-a', body=b'<html>A</html>')
+        mock_client.respond_to(r'page-b', body=b'<html>B</html>')
+
+        diff_region = self._make_memory_region_for_test()
+        resp_region = self._make_memory_region_for_test()
+
+        with patch.object(cache_module, '_get_response_region', return_value=resp_region), \
+             patch.object(cache_module, '_get_diff_region', return_value=diff_region):
+
+            r1 = self.fetch(f'/identical_bytes?a={url_a}&b={url_b}')
+            assert r1.code == 200
+            body1 = json.loads(r1.body)
+
+            r2 = self.fetch(f'/identical_bytes?a={url_a}&b={url_b}')
+            assert r2.code == 200
+            body2 = json.loads(r2.body)
+
+            # Both responses should carry the same diff payload.
+            assert body1['type'] == body2['type']
+
+    @mock_http_client_decorator
+    def test_diff_cache_disabled_when_expiration_zero(self, mock_client):
+        """Setting CACHE_DIFF_EXPIRATION_SECONDS=0 should skip diff caching."""
+        url_a = 'https://example.org/page-a'
+        url_b = 'https://example.org/page-b'
+        mock_client.respond_to(r'page-a', body=b'<html>A</html>')
+        mock_client.respond_to(r'page-b', body=b'<html>B</html>')
+
+        with patch.object(cache_module, 'CACHE_DIFF_EXPIRATION_SECONDS', 0), \
+             patch.object(cache_module, '_get_response_region',
+                          return_value=self._make_memory_region_for_test()), \
+             patch.object(cache_module, '_get_diff_region',
+                          return_value=self._make_memory_region_for_test()):
+
+            r1 = self.fetch(f'/identical_bytes?a={url_a}&b={url_b}')
+            r2 = self.fetch(f'/identical_bytes?a={url_a}&b={url_b}')
+            # Both should succeed; the key thing is no error is raised.
+            assert r1.code == 200
+            assert r2.code == 200
+
+    def test_file_urls_are_not_cached(self):
+        """
+        Responses from file:// URLs must not be stored in the response cache
+        (it only makes sense to cache HTTP responses).
+        """
+        region = self._make_memory_region_for_test()
+        with patch.object(cache_module, '_get_response_region', return_value=region), \
+             patch.object(cache_module, '_get_diff_region',
+                          return_value=self._make_memory_region_for_test()):
+
+            path = fixture_path('empty.txt')
+            url = f'file://{path}'
+            # Trigger a diff using local files.
+            response = self.fetch(
+                f'/identical_bytes?a={url}&b={url}')
+            assert response.code == 200
+
+            # The response cache region should be empty because we only cache
+            # HTTP/HTTPS URLs.
+            from dogpile.cache.api import NO_VALUE
+            cache_key = make_response_cache_key(url)
+            assert region.get(cache_key) is NO_VALUE

--- a/web_monitoring_diff/tests/test_server_caching.py
+++ b/web_monitoring_diff/tests/test_server_caching.py
@@ -9,8 +9,12 @@ cache correctly.
 
 import json
 import unittest
+import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
+
+# Skip all tests in this file if the optional cache package is not installed.
+pytest.importorskip("dogpile.cache")
 
 from tornado.testing import AsyncHTTPTestCase
 


### PR DESCRIPTION
Introduces a robust caching layer using [dogpile.cache](https://dogpilecache.sqlalchemy.org/en/latest/) to temporarily store raw HTTP response bodies and computed diff results. Defaults to an in-memory fallback, but seamlessly scales to use a Redis backend (with `hiredis` acceleration) when `CACHE_REDIS_URL` is provided in the environment. This vastly improves server performance by skipping redundant network payloads and heavy HTML processing when comparing previously requested URLs.


```
time curl -s "http://localhost:8882/html_token?a=https://web.archive.org/web/20260110134549/https://en.wikipedia.org/\&b=https://web.archive.org/web/20260112035545/https://en.wikipedia.org/" > /dev/null

> curl -s  > /dev/null  0.00s user 0.01s system 0% cpu 6.637 total

time curl -s "http://localhost:8882/html_token?a=https://web.archive.org/web/20260110134549/https://en.wikipedia.org/\&b=https://web.archive.org/web/20260112035545/https://en.wikipedia.org/" > /dev/null
> curl -s  > /dev/null  0.01s user 0.00s system 79% cpu 0.017 total


```
closes: #242 
