### PR TITLE
Use dotenv

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -4,7 +4,11 @@ Configuration
 
 The diff server and some diffing algorithms can be configured via environment variables. All variables are optional; defaults are noted below.
 
-A template listing all variables is available in `.env.example <https://github.com/edgi-govdata-archiving/web-monitoring-diff/blob/main/.env.example>`_ at the root of the repository.
+A template listing all variables is available in `.env.example`_ at the root of the repository.
+
+When running the diff server from the command line, it will load these variables from a file named ``.env`` in the project directory, which can be helpful for configuration in your local development environment. The file should be formatted as a list of bash-style variable declarations, like the `.env.example`_ file.
+
+.. _.env.example: https://github.com/edgi-govdata-archiving/web-monitoring-diff/blob/main/.env.example
 
 
 Diff Settings

--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -6,6 +6,7 @@ In Development
 --------------
 
 - Move mock request/response classes into a separate submodule of `server`. (:issue:`226`)
+- Server automatically loads configuration from `.env` file if present. (:issue:`247`)
 
 
 Version 0.2.0 (2026-03-16)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 # Dependencies for the HTTP server.
 server = [
+    "python-dotenv",
     "chardet >=5.0.0,<6",
     "pycurl >=7.43,<8",
     "sentry-sdk[tornado] >=2.0.0,<3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 # Dependencies for the HTTP server.
 server = [
-    "python-dotenv",
+    "python-dotenv >= 1.2.2",
     "chardet >=5.0.0,<6",
     "pycurl >=7.43,<8",
     "sentry-sdk[tornado] >=2.0.0,<3.0",

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -25,9 +25,6 @@ from .. import basic_diffs, html_render_diff, html_links_diff
 from ..exceptions import UndiffableContentError, UndecodableContentError
 from ..utils import shutdown_executor_in_loop, Signal
 
-# reads variables from a .env file and sets them in os.environ
-load_dotenv()
-
 # Where possible, use cchardet (or faust-cchardet) for performance.
 # Unfortunately these aren't supported in the latest Python vesions, so we also
 # fall back to something in pure Python for those cases. There are a few
@@ -791,6 +788,9 @@ def cli():
     if arguments.version:
         print(web_monitoring_diff.__version__)
         return
+
+    # Update os.environ with values from `.env` file, if present.
+    load_dotenv()
 
     start_app(arguments.port)
 

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -12,11 +12,7 @@ import re
 import sentry_sdk
 import signal
 import sys
-try:
-    from dotenv import load_dotenv
-    load_dotenv()
-except ImportError:
-    pass
+from dotenv import load_dotenv
 from tornado.curl_httpclient import CurlAsyncHTTPClient, CurlError
 import tornado.simple_httpclient
 import tornado.httpclient
@@ -28,6 +24,9 @@ from .mock_http import MockResponse
 from .. import basic_diffs, html_render_diff, html_links_diff
 from ..exceptions import UndiffableContentError, UndecodableContentError
 from ..utils import shutdown_executor_in_loop, Signal
+
+# reads variables from a .env file and sets them in os.environ
+load_dotenv()
 
 # Where possible, use cchardet (or faust-cchardet) for performance.
 # Unfortunately these aren't supported in the latest Python vesions, so we also

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -12,6 +12,11 @@ import re
 import sentry_sdk
 import signal
 import sys
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
 from tornado.curl_httpclient import CurlAsyncHTTPClient, CurlError
 import tornado.simple_httpclient
 import tornado.httpclient


### PR DESCRIPTION
Adds support for python-dotenv to automatically load environment variables from `.env` files when starting the server, closes #26. I feel like 99% of the time having a try...except for the import won't matter, but technically it's more of a soft dependency and server.py doesn't "need" `python-dotenv` to run.