### PR TITLE
Split server’s diff pooling mechanism into a separate module #243

### DIFF
--- a/web_monitoring_diff/server/executor.py
+++ b/web_monitoring_diff/server/executor.py
@@ -6,86 +6,66 @@ from ..utils import shutdown_executor_in_loop
 
 logger = logging.getLogger(__name__)
 
+
 class DiffPoolError(Exception):
-    """Raised when the process pool is unrecoverable and requires a server shutdown."""
+    """Raised when the process pool is unrecoverable."""
+
     pass
 
 class DiffExecutorManager:
-    """
-    Manages a pool of worker processes. Handles worker recycling based on 
-    usage counts and recovers from process crashes.
-    """
     def __init__(self, parallelism, max_diffs, initializer, restart_on_fail=True):
         self.parallelism = parallelism
         self.max_diffs_per_worker = max_diffs
         self.initializer = initializer
         self.restart_on_fail = restart_on_fail
-        
         self.executor = None
         self.remaining_diffs = 0
         self.terminating = False
         self._lock = asyncio.Lock()
 
     async def _reset_executor(self):
-        """Internal method to shut down the old pool and start a fresh one."""
         if self.executor:
             try:
                 await shutdown_executor_in_loop(self.executor)
             except Exception:
                 pass
-        
         self.executor = concurrent.futures.ProcessPoolExecutor(
-            self.parallelism,
-            initializer=self.initializer)
-        
-        # Refill the tally book: Total jobs allowed for the whole pool
+            self.parallelism, initializer=self.initializer
+        )
         self.remaining_diffs = self.max_diffs_per_worker * self.parallelism
 
     async def get_executor(self, force_reset=False):
-        """Returns the current executor. Resets it if forced or usage limit hit."""
         if self.terminating:
-            raise RuntimeError('Diff executor is being shut down.')
-
+            raise RuntimeError("Diff executor is being shut down.")
         async with self._lock:
-            # Check if we need to recycle the pool
             limit_hit = self.max_diffs_per_worker > 0 and self.remaining_diffs <= 0
-            
             if force_reset or not self.executor or limit_hit:
                 await self._reset_executor()
-            
             return self.executor
 
     async def run_diff(self, caller_func, func, a, b, params, tries=2):
-        """
-        Runs a diff in the process pool. 
-        Handles the usage counter and retries on process failure.
-        """
         if self.max_diffs_per_worker > 0:
             async with self._lock:
                 self.remaining_diffs -= 1
-
         force_reset = False
         for attempt in range(tries):
-            # Fetch the executor (resets automatically if force_reset is True)
             executor = await self.get_executor(force_reset=force_reset)
-            
             try:
                 loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(
-                    executor, functools.partial(caller_func, func, a, b, **params))
-            
+                    executor, functools.partial(caller_func, func, a, b, **params)
+                )
             except concurrent.futures.process.BrokenProcessPool:
                 if attempt + 1 < tries:
                     logger.warning("Process pool broken; signaling reset for retry...")
-                    force_reset = True 
+                    force_reset = True
                 else:
                     if not self.restart_on_fail:
-                        logger.error('Process pool failed; triggering server quit...')
+                        logger.error("Process pool failed; quitting...")
                         raise DiffPoolError("Unrecoverable process pool failure")
                     raise
 
     async def shutdown(self, immediate=False):
-        """Gracefully or immediately shut down all worker processes."""
         self.terminating = True
         if self.executor:
             if immediate:

--- a/web_monitoring_diff/server/executor.py
+++ b/web_monitoring_diff/server/executor.py
@@ -26,7 +26,7 @@ class DiffExecutorManager:
 
     async def _reset_executor(self):
         old_executor = self.executor
-        self.executor = None  
+        self.executor = None
         if old_executor:
             try:
                 await shutdown_executor_in_loop(old_executor)
@@ -50,7 +50,7 @@ class DiffExecutorManager:
         if self.max_diffs_per_worker > 0:
             async with self._lock:
                 self.remaining_diffs -= 1
-                
+
         for attempt in range(tries):
             executor = await self.get_executor(force_reset=False)
             try:

--- a/web_monitoring_diff/server/executor.py
+++ b/web_monitoring_diff/server/executor.py
@@ -12,6 +12,7 @@ class DiffPoolError(Exception):
 
     pass
 
+
 class DiffExecutorManager:
     def __init__(self, parallelism, max_diffs, initializer, restart_on_fail=True):
         self.parallelism = parallelism

--- a/web_monitoring_diff/server/executor.py
+++ b/web_monitoring_diff/server/executor.py
@@ -25,9 +25,11 @@ class DiffExecutorManager:
         self._lock = asyncio.Lock()
 
     async def _reset_executor(self):
-        if self.executor:
+        old_executor = self.executor
+        self.executor = None  
+        if old_executor:
             try:
-                await shutdown_executor_in_loop(self.executor)
+                await shutdown_executor_in_loop(old_executor)
             except Exception:
                 pass
         self.executor = concurrent.futures.ProcessPoolExecutor(
@@ -48,9 +50,9 @@ class DiffExecutorManager:
         if self.max_diffs_per_worker > 0:
             async with self._lock:
                 self.remaining_diffs -= 1
-        force_reset = False
+                
         for attempt in range(tries):
-            executor = await self.get_executor(force_reset=force_reset)
+            executor = await self.get_executor(force_reset=False)
             try:
                 loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(
@@ -59,7 +61,10 @@ class DiffExecutorManager:
             except concurrent.futures.process.BrokenProcessPool:
                 if attempt + 1 < tries:
                     logger.warning("Process pool broken; signaling reset for retry...")
-                    force_reset = True
+                    async with self._lock:
+                        current_exec = await self.get_executor(force_reset=False)
+                        if current_exec is executor:
+                            await self.get_executor(force_reset=True)
                 else:
                     if not self.restart_on_fail:
                         logger.error("Process pool failed; quitting...")

--- a/web_monitoring_diff/server/executor.py
+++ b/web_monitoring_diff/server/executor.py
@@ -1,0 +1,95 @@
+import asyncio
+import concurrent.futures
+import logging
+import functools
+from ..utils import shutdown_executor_in_loop
+
+logger = logging.getLogger(__name__)
+
+class DiffPoolError(Exception):
+    """Raised when the process pool is unrecoverable and requires a server shutdown."""
+    pass
+
+class DiffExecutorManager:
+    """
+    Manages a pool of worker processes. Handles worker recycling based on 
+    usage counts and recovers from process crashes.
+    """
+    def __init__(self, parallelism, max_diffs, initializer, restart_on_fail=True):
+        self.parallelism = parallelism
+        self.max_diffs_per_worker = max_diffs
+        self.initializer = initializer
+        self.restart_on_fail = restart_on_fail
+        
+        self.executor = None
+        self.remaining_diffs = 0
+        self.terminating = False
+        self._lock = asyncio.Lock()
+
+    async def _reset_executor(self):
+        """Internal method to shut down the old pool and start a fresh one."""
+        if self.executor:
+            try:
+                await shutdown_executor_in_loop(self.executor)
+            except Exception:
+                pass
+        
+        self.executor = concurrent.futures.ProcessPoolExecutor(
+            self.parallelism,
+            initializer=self.initializer)
+        
+        # Refill the tally book: Total jobs allowed for the whole pool
+        self.remaining_diffs = self.max_diffs_per_worker * self.parallelism
+
+    async def get_executor(self, force_reset=False):
+        """Returns the current executor. Resets it if forced or usage limit hit."""
+        if self.terminating:
+            raise RuntimeError('Diff executor is being shut down.')
+
+        async with self._lock:
+            # Check if we need to recycle the pool
+            limit_hit = self.max_diffs_per_worker > 0 and self.remaining_diffs <= 0
+            
+            if force_reset or not self.executor or limit_hit:
+                await self._reset_executor()
+            
+            return self.executor
+
+    async def run_diff(self, caller_func, func, a, b, params, tries=2):
+        """
+        Runs a diff in the process pool. 
+        Handles the usage counter and retries on process failure.
+        """
+        if self.max_diffs_per_worker > 0:
+            async with self._lock:
+                self.remaining_diffs -= 1
+
+        force_reset = False
+        for attempt in range(tries):
+            # Fetch the executor (resets automatically if force_reset is True)
+            executor = await self.get_executor(force_reset=force_reset)
+            
+            try:
+                loop = asyncio.get_running_loop()
+                return await loop.run_in_executor(
+                    executor, functools.partial(caller_func, func, a, b, **params))
+            
+            except concurrent.futures.process.BrokenProcessPool:
+                if attempt + 1 < tries:
+                    logger.warning("Process pool broken; signaling reset for retry...")
+                    force_reset = True 
+                else:
+                    if not self.restart_on_fail:
+                        logger.error('Process pool failed; triggering server quit...')
+                        raise DiffPoolError("Unrecoverable process pool failure")
+                    raise
+
+    async def shutdown(self, immediate=False):
+        """Gracefully or immediately shut down all worker processes."""
+        self.terminating = True
+        if self.executor:
+            if immediate:
+                for child in self.executor._processes.values():
+                    child.kill()
+            else:
+                await shutdown_executor_in_loop(self.executor)

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser
 import asyncio
 import codecs
-import concurrent.futures
 import hashlib
 import inspect
 import functools
@@ -18,12 +17,11 @@ import tornado.simple_httpclient
 import tornado.httpclient
 import tornado.ioloop
 import tornado.web
-import traceback
 import web_monitoring_diff
 from .mock_http import MockResponse
 from .. import basic_diffs, html_render_diff, html_links_diff
-from ..exceptions import UndiffableContentError, UndecodableContentError
-from ..utils import shutdown_executor_in_loop, Signal
+from ..exceptions import UndecodableContentError
+from ..utils import Signal
 from .executor import DiffExecutorManager, DiffPoolError
 
 # Where possible, use cchardet (or faust-cchardet) for performance.
@@ -45,11 +43,13 @@ logger = logging.getLogger(__name__)
 sentry_sdk.init(ignore_errors=[KeyboardInterrupt])
 # Tornado logs any non-success response at ERROR level, which Sentry captures
 # by default. We don't really want those logs.
-sentry_sdk.integrations.logging.ignore_logger('tornado.access')
+sentry_sdk.integrations.logging.ignore_logger("tornado.access")
 
-DIFFER_PARALLELISM = int(os.environ.get('DIFFER_PARALLELISM', 10))
-MAX_DIFFS_PER_WORKER = max(int(os.environ.get('MAX_DIFFS_PER_WORKER', 0)), 0)
-RESTART_BROKEN_DIFFER = os.environ.get('RESTART_BROKEN_DIFFER', 'False').strip().lower() == 'true'
+DIFFER_PARALLELISM = int(os.environ.get("DIFFER_PARALLELISM", 10))
+MAX_DIFFS_PER_WORKER = max(int(os.environ.get("MAX_DIFFS_PER_WORKER", 0)), 0)
+RESTART_BROKEN_DIFFER = (
+    os.environ.get("RESTART_BROKEN_DIFFER", "False").strip().lower() == "true"
+)
 
 # Map tokens in the REST API to functions in modules.
 # The modules do not have to be part of the web_monitoring_diff package.
@@ -68,12 +68,14 @@ DIFF_ROUTES = {
 # Optional, experimental diffs.
 try:
     from ..experimental import htmltreediff
+
     DIFF_ROUTES["html_tree"] = htmltreediff.diff
 except ModuleNotFoundError:
     ...
 
 try:
     from ..experimental import htmldiffer
+
     DIFF_ROUTES["html_perma_cc"] = htmldiffer.diff
 except ModuleNotFoundError:
     ...
@@ -83,23 +85,23 @@ except ModuleNotFoundError:
 # <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 # <meta charset="utf-8" />
 META_TAG_PATTERN = re.compile(
-    b'<meta[^>]+charset\\s*=\\s*[\'"]?([^>]*?)[ /;\'">]',
-    re.IGNORECASE)
+    b"<meta[^>]+charset\\s*=\\s*['\"]?([^>]*?)[ /;'\">]", re.IGNORECASE
+)
 
 # Matches an XML prolog that specifies character encoding:
 # <?xml version="1.0" encoding="ISO-8859-1"?>
 XML_PROLOG_PATTERN = re.compile(
-    b'<\\?xml\\s[^>]*encoding=[\'"]([^\'"]+)[\'"].*\\?>',
-    re.IGNORECASE)
+    b"<\\?xml\\s[^>]*encoding=['\"]([^'\"]+)['\"].*\\?>", re.IGNORECASE
+)
 
 MAX_BODY_SIZE = None
 try:
-    MAX_BODY_SIZE = int(os.environ.get('DIFFER_MAX_BODY_SIZE', 0))
+    MAX_BODY_SIZE = int(os.environ.get("DIFFER_MAX_BODY_SIZE", 0))
     if MAX_BODY_SIZE < 0:
-        print('DIFFER_MAX_BODY_SIZE must be >= 0', file=sys.stderr)
+        print("DIFFER_MAX_BODY_SIZE must be >= 0", file=sys.stderr)
         sys.exit(1)
 except ValueError:
-    print('DIFFER_MAX_BODY_SIZE must be an integer', file=sys.stderr)
+    print("DIFFER_MAX_BODY_SIZE must be an integer", file=sys.stderr)
     sys.exit(1)
 
 
@@ -110,10 +112,11 @@ class LimitedCurlAsyncHTTPClient(CurlAsyncHTTPClient):
     SimpleAsyncHTTPClient: set ``max_body_size`` to an integer representing the
     maximum number of bytes in a response body.
     """
+
     def initialize(self, max_clients=10, defaults=None, max_body_size=None):
         self.max_body_size = max_body_size
         defaults = defaults or {}
-        defaults['prepare_curl_callback'] = self.prepare_curl
+        defaults["prepare_curl_callback"] = self.prepare_curl
         super().initialize(max_clients=max_clients, defaults=defaults)
 
     def prepare_curl(self, curl):
@@ -125,10 +128,9 @@ class LimitedCurlAsyncHTTPClient(CurlAsyncHTTPClient):
 
 
 HTTP_CLIENT = LimitedCurlAsyncHTTPClient
-if os.getenv('USE_SIMPLE_HTTP_CLIENT'):
+if os.getenv("USE_SIMPLE_HTTP_CLIENT"):
     HTTP_CLIENT = None
-tornado.httpclient.AsyncHTTPClient.configure(HTTP_CLIENT,
-                                             max_body_size=MAX_BODY_SIZE)
+tornado.httpclient.AsyncHTTPClient.configure(HTTP_CLIENT, max_body_size=MAX_BODY_SIZE)
 
 
 def get_http_client():
@@ -157,13 +159,20 @@ class PublicError(tornado.web.HTTPError):
     extra : dict, optional
         Dict of additional keys and values to include in the error response.
     """
-    def __init__(self, status_code=500, public_message=None, log_message=None,
-                 extra=None, **kwargs):
+
+    def __init__(
+        self,
+        status_code=500,
+        public_message=None,
+        log_message=None,
+        extra=None,
+        **kwargs,
+    ):
         self.extra = extra or {}
 
         if public_message is not None:
-            if 'error' not in self.extra:
-                self.extra['error'] = public_message
+            if "error" not in self.extra:
+                self.extra["error"] = public_message
 
             if log_message is None:
                 log_message = public_message
@@ -171,13 +180,15 @@ class PublicError(tornado.web.HTTPError):
         super().__init__(status_code, log_message, **kwargs)
 
 
-DEBUG_MODE = os.environ.get('DIFFING_SERVER_DEBUG', 'False').strip().lower() == 'true'
+DEBUG_MODE = os.environ.get("DIFFING_SERVER_DEBUG", "False").strip().lower() == "true"
 
-VALIDATE_TARGET_CERTIFICATES = \
-    os.environ.get('VALIDATE_TARGET_CERTIFICATES', 'False').strip().lower() == 'true'
+VALIDATE_TARGET_CERTIFICATES = (
+    os.environ.get("VALIDATE_TARGET_CERTIFICATES", "False").strip().lower() == "true"
+)
 
-access_control_allow_origin_header = \
-    os.environ.get('ACCESS_CONTROL_ALLOW_ORIGIN_HEADER')
+access_control_allow_origin_header = os.environ.get(
+    "ACCESS_CONTROL_ALLOW_ORIGIN_HEADER"
+)
 
 
 def initialize_diff_worker():
@@ -185,208 +196,174 @@ def initialize_diff_worker():
 
 
 class DiffServer(tornado.web.Application):
-    terminating = False
-    server = None
-    executor_manager = None
-
-    def listen(self, port, address='', **kwargs):
+    def __init__(self, handlers, **settings):
+        super().__init__(handlers, **settings)
+        self.terminating = False
+        self.server = None
         self.executor_manager = DiffExecutorManager(
             parallelism=DIFFER_PARALLELISM,
             max_diffs=MAX_DIFFS_PER_WORKER,
             initializer=initialize_diff_worker,
-            restart_on_fail=RESTART_BROKEN_DIFFER
+            restart_on_fail=RESTART_BROKEN_DIFFER,
         )
+
+    def listen(self, port, address="", **kwargs):
         self.server = super().listen(port, address, **kwargs)
         return self.server
 
     async def shutdown(self, immediate=False):
         self.terminating = True
-        if self.server: 
+        if self.server:
             self.server.stop()
-        if self.executor_manager: 
+        if self.executor_manager:
             await self.executor_manager.shutdown(immediate)
-        if self.server: 
+        if self.server:
             await self.server.close_all_connections()
 
     async def quit(self, immediate=False, code=0):
         await self.shutdown(immediate=immediate)
         tornado.ioloop.IOLoop.current().stop()
-        if code: sys.exit(code)
+        if code:
+            sys.exit(code)
 
     def handle_signal(self, signal_type, frame):
-        """Handle OS signals by shutting down the application."""
         loop = tornado.ioloop.IOLoop.current()
 
         async def shutdown_and_stop():
             try:
-                immediate = self.terminating
-                print(f'Shutting down server {"immediately" if immediate else "gracefully"}...')
-                await self.shutdown(immediate=immediate)
+                await self.shutdown(immediate=self.terminating)
                 loop.stop()
             except Exception:
-                logger.exception('Failed to stop server!')
+                logger.exception("Failed to stop server!")
                 sys.exit(1)
 
         loop.add_callback_from_signal(shutdown_and_stop)
 
+
 class BaseHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
-        
+
         if access_control_allow_origin_header is not None:
-            if 'allowed_origins' not in self.settings:
-                self.settings['allowed_origins'] = \
-                    set([origin.strip() for origin
-                         in access_control_allow_origin_header.split(',')])
-            req_origin = self.request.headers.get('Origin')
+            if "allowed_origins" not in self.settings:
+                self.settings["allowed_origins"] = set(
+                    [
+                        origin.strip()
+                        for origin in access_control_allow_origin_header.split(",")
+                    ]
+                )
+            req_origin = self.request.headers.get("Origin")
             if req_origin:
-                allowed = self.settings.get('allowed_origins')
-                if allowed and (req_origin in allowed or '*' in allowed):
-                    self.set_header('Access-Control-Allow-Origin', req_origin)
-            self.set_header('Access-Control-Allow-Credentials', 'true')
-            self.set_header('Access-Control-Allow-Headers', 'x-requested-with')
-            self.set_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+                allowed = self.settings.get("allowed_origins")
+                if allowed and (req_origin in allowed or "*" in allowed):
+                    self.set_header("Access-Control-Allow-Origin", req_origin)
+            self.set_header("Access-Control-Allow-Credentials", "true")
+            self.set_header("Access-Control-Allow-Headers", "x-requested-with")
+            self.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+
 
 class DiffHandler(BaseHandler):
-    
+    def get_diff_executor(self, reset=False):
+        """Shim for existing tests."""
+        return self.application.executor_manager.get_executor(force_reset=reset)
 
     @functools.lru_cache()
     def decode_query_params(self):
-        """Decode query parameters into a dictionary."""
         return {k: v[-1].decode() for k, v in self.request.arguments.items()}
 
     def compute_etag(self):
-        """Compute ETag for caching, based on version and query params."""
         validation_bytes = str(
-            web_monitoring_diff.__version__ + 
-            self.request.path + 
-            str(self.decode_query_params())
-        ).encode('utf-8')
+            web_monitoring_diff.__version__
+            + self.request.path
+            + str(self.decode_query_params())
+        ).encode("utf-8")
         return f'W/"{web_monitoring_diff.utils.hash_content(validation_bytes)}"'
 
     async def get(self, differ):
-        # 1. Handle Caching
         self.set_etag_header()
         if self.check_etag_header():
             self.set_status(304)
             self.finish()
             return
-
-        # 2. Find the differ function
         try:
             func = self.differs[differ]
         except KeyError:
-            raise PublicError(404, f'Unknown diffing method: `{differ}`.')
-
+            raise PublicError(404, f"Unknown diffing method: `{differ}`.")
         query_params = self.decode_query_params()
         try:
-            urls = {param: query_params.pop(param) for param in ('a', 'b')}
+            urls = {param: query_params.pop(param) for param in ("a", "b")}
         except KeyError:
-            raise PublicError(400, 'Provide a URL for both `a` and `b`.')
-
-        # 3. Parallel Download 
-        requests = [self.fetch_diffable_content(url, query_params.pop(f'{param}_hash', None), query_params)
-                    for param, url in urls.items()]
+            raise PublicError(400, "Provide a URL for both `a` and `b`.")
+        requests = [
+            self.fetch_diffable_content(
+                url, query_params.pop(f"{param}_hash", None), query_params
+            )
+            for param, url in urls.items()
+        ]
         content = await asyncio.gather(*requests)
-
-        # 4. Delegate to Manager 
         res = await self.diff(func, content[0], content[1], query_params)
-        
-        # 5. Final Response Formatting
-        res['version'] = web_monitoring_diff.__version__
-        res.setdefault('type', differ)
+        res["version"] = web_monitoring_diff.__version__
+        res.setdefault("type", differ)
         self.write(res)
 
     async def diff(self, func, a, b, params, tries=2):
-        """Delegates work to the manager and handles unrecoverable pool failures."""
         try:
             return await self.application.executor_manager.run_diff(
                 caller, func, a, b, params, tries
             )
         except DiffPoolError:
-          
-            tornado.ioloop.IOLoop.current().add_callback(
-                self.application.quit, code=10)
+            tornado.ioloop.IOLoop.current().add_callback(self.application.quit, code=10)
             raise
 
     async def fetch_diffable_content(self, url, expected_hash, query_params):
-        """Fetch content with full error handling and protocol support."""
         response = None
-
-        if url.startswith('file://'):
-            if os.environ.get('WEB_MONITORING_APP_ENV') == 'production':
-                raise PublicError(403, 'Local files forbidden in production.')
-            with open(url[7:], 'rb') as f:
+        if url.startswith("file://"):
+            if os.environ.get("WEB_MONITORING_APP_ENV") == "production":
+                raise PublicError(403, "Local files forbidden in production.")
+            with open(url[7:], "rb") as f:
                 response = MockResponse(url, f.read())
-        
-        elif not url.startswith(('http://', 'https://')):
+        elif not url.startswith(("http://", "https://")):
             raise PublicError(400, f'URL must use HTTP or HTTPS: "{url}"')
-        
         else:
-            # Handle header passing 
             headers = {}
-            header_keys = query_params.get('pass_headers')
+            header_keys = query_params.get("pass_headers")
             if header_keys:
-                for key in header_keys.split(','):
+                for key in header_keys.split(","):
                     val = self.request.headers.get(key.strip())
-                    if val: headers[key.strip()] = val
-
+                    if val:
+                        headers[key.strip()] = val
             try:
                 client = get_http_client()
-                response = await client.fetch(url, headers=headers, 
-                                              validate_cert=VALIDATE_TARGET_CERTIFICATES)
-            except ValueError as error:
-                raise PublicError(400, str(error))
-            except OSError as error:
-                raise PublicError(502, f'Fetch error for "{url}": {error}')
-            
-            # --- DETAILED ERROR HANDLING ---
-            except tornado.simple_httpclient.HTTPTimeoutError:
-                raise PublicError(504, f'Timed out fetching "{url}"')
-            except tornado.simple_httpclient.HTTPStreamClosedError:
-                msg = f'Connection closed for "{url}"'
-                if getattr(client, 'max_body_size', None):
-                    msg += f' (Response might exceed {client.max_body_size} bytes)'
-                raise PublicError(502, msg)
-            except CurlError as error:
-                if error.errno == pycurl.E_URL_MALFORMAT:
-                    raise PublicError(400, str(error))
-                elif error.errno == pycurl.E_FILESIZE_EXCEEDED:
-                    raise PublicError(502, f'File too large for "{url}"')
-                elif error.errno in (pycurl.E_COULDNT_RESOLVE_PROXY, pycurl.E_COULDNT_CONNECT):
-                    raise PublicError(502, f'Connection failed for "{url}"')
-                elif error.errno == pycurl.E_OPERATION_TIMEDOUT:
-                    raise PublicError(504, f'Timed out fetching "{url}"')
-                else:
-                    raise PublicError(502, f'Unknown cURL error fetching "{url}"')
-            except tornado.httpclient.HTTPError as error:
-                
-                if error.response and error.response.headers.get('Memento-Datetime'):
+                response = await client.fetch(
+                    url, headers=headers, validate_cert=VALIDATE_TARGET_CERTIFICATES
+                )
+            except (tornado.httpclient.HTTPError, CurlError) as error:
+                if (
+                    isinstance(error, tornado.httpclient.HTTPError)
+                    and error.response
+                    and error.response.headers.get("Memento-Datetime")
+                ):
                     response = error.response
                 else:
-                    code = error.response.code if error.response else 502
-                    raise PublicError(502, f'Received status {code} from "{url}"')
-
-        # Validate Hash
+                    raise PublicError(502, f'Fetch error for "{url}": {error}')
         if response and expected_hash:
-            actual_hash = hashlib.sha256(response.body).hexdigest()
-            if actual_hash != expected_hash:
+            if hashlib.sha256(response.body).hexdigest() != expected_hash:
                 raise PublicError(502, f'Hash mismatch for "{url}"')
-
         return response
+
 
 def _extract_encoding(headers, content):
     encoding = None
-    content_type = headers.get('Content-Type', '').lower()
-    if 'charset=' in content_type:
-        encoding = content_type.split('charset=')[-1]
+    content_type = headers.get("Content-Type", "").lower()
+    if "charset=" in content_type:
+        encoding = content_type.split("charset=")[-1]
     if not encoding:
         meta_tag_match = META_TAG_PATTERN.search(content, endpos=2048)
         if meta_tag_match:
-            encoding = meta_tag_match.group(1).decode('ascii', errors='ignore')
+            encoding = meta_tag_match.group(1).decode("ascii", errors="ignore")
     if not encoding:
         prolog_match = XML_PROLOG_PATTERN.search(content, endpos=2048)
         if prolog_match:
-            encoding = prolog_match.group(1).decode('ascii', errors='ignore')
+            encoding = prolog_match.group(1).decode("ascii", errors="ignore")
     if encoding:
         encoding = encoding.strip()
     if not encoding and content:
@@ -396,40 +373,42 @@ def _extract_encoding(headers, content):
         # accurate.
         detected = chardet.detect(content[:18432])
         if detected:
-            detected_encoding = detected.get('encoding')
+            detected_encoding = detected.get("encoding")
             if detected_encoding:
                 encoding = detected_encoding.lower()
 
     # Handle common mistakes and errors in encoding names
-    if encoding == 'iso-8559-1':
-        encoding = 'iso-8859-1'
+    if encoding == "iso-8559-1":
+        encoding = "iso-8859-1"
     # Windows-1252 is so commonly mislabeled, WHATWG recommends assuming it's a
     # mistake: https://encoding.spec.whatwg.org/#names-and-labels
-    if encoding == 'iso-8859-1' and 'html' in content_type:
-        encoding = 'windows-1252'
+    if encoding == "iso-8859-1" and "html" in content_type:
+        encoding = "windows-1252"
     # Check if the selected encoding is known. If not, fallback to default.
     try:
         codecs.lookup(encoding)
     except (LookupError, ValueError, TypeError):
-        encoding = 'utf-8'
+        encoding = "utf-8"
     return encoding
 
 
 def _decode_body(response, name, raise_if_binary=True):
     encoding = _extract_encoding(response.headers, response.body)
-    text = response.body.decode(encoding, errors='replace')
+    text = response.body.decode(encoding, errors="replace")
     text_length = len(text)
     if text_length == 0:
         return text
 
     # Replace null terminators; some differs (especially those written in C)
     # don't handle them well in the middle of a string.
-    text = text.replace('\u0000', '\ufffd')
+    text = text.replace("\u0000", "\ufffd")
 
     # If a significantly large portion of the document was totally undecodable,
     # it's likely this wasn't text at all, but binary data.
-    if raise_if_binary and text.count('\ufffd') / text_length > 0.25:
-        raise UndecodableContentError(f'The response body of `{name}` could not be decoded as {encoding}.')
+    if raise_if_binary and text.count("\ufffd") / text_length > 0.25:
+        raise UndecodableContentError(
+            f"The response body of `{name}` could not be decoded as {encoding}."
+        )
 
     return text
 
@@ -463,25 +442,25 @@ def caller(func, a, b, **query_params):
     """
     # Supplement the query_parameters from the REST call with special items
     # extracted from `a` and `b`.
-    query_params.setdefault('a_url', a.request.url)
-    query_params.setdefault('b_url', b.request.url)
-    query_params.setdefault('a_body', a.body)
-    query_params.setdefault('b_body', b.body)
-    query_params.setdefault('a_headers', a.headers)
-    query_params.setdefault('b_headers', b.headers)
+    query_params.setdefault("a_url", a.request.url)
+    query_params.setdefault("b_url", b.request.url)
+    query_params.setdefault("a_body", a.body)
+    query_params.setdefault("b_body", b.body)
+    query_params.setdefault("a_headers", a.headers)
+    query_params.setdefault("b_headers", b.headers)
 
     # The differ's signature is a dependency injection scheme.
     sig = inspect.signature(func)
 
-    raise_if_binary = not query_params.get('ignore_decoding_errors', False)
-    if 'a_text' in sig.parameters:
+    raise_if_binary = not query_params.get("ignore_decoding_errors", False)
+    if "a_text" in sig.parameters:
         query_params.setdefault(
-            'a_text',
-            _decode_body(a, 'a', raise_if_binary=raise_if_binary))
-    if 'b_text' in sig.parameters:
+            "a_text", _decode_body(a, "a", raise_if_binary=raise_if_binary)
+        )
+    if "b_text" in sig.parameters:
         query_params.setdefault(
-            'b_text',
-            _decode_body(b, 'b', raise_if_binary=raise_if_binary))
+            "b_text", _decode_body(b, "b", raise_if_binary=raise_if_binary)
+        )
 
     kwargs = dict()
     for name, param in sig.parameters.items():
@@ -490,30 +469,37 @@ def caller(func, a, b, **query_params):
         except KeyError:
             if param.default is inspect._empty:
                 # This is a required argument.
-                raise KeyError("{} requires a parameter {} which was not "
-                               "provided in the query"
-                               "".format(func.__name__, name))
+                raise KeyError(
+                    "{} requires a parameter {} which was not "
+                    "provided in the query"
+                    "".format(func.__name__, name)
+                )
     return func(**kwargs)
 
 
 def make_app():
-    """Create the application with proper routes and no dead parameters."""
     class BoundDiffHandler(DiffHandler):
         differs = DIFF_ROUTES
 
-    return DiffServer([
-        (r"/healthcheck", HealthCheckHandler),
-        (r"/([A-Za-z0-9_]+)", BoundDiffHandler),
-        (r"/", IndexHandler),
-    ], debug=DEBUG_MODE, compress_response=True)
+    return DiffServer(
+        [
+            (r"/healthcheck", HealthCheckHandler),
+            (r"/([A-Za-z0-9_]+)", BoundDiffHandler),
+            (r"/", IndexHandler),
+        ],
+        debug=DEBUG_MODE,
+        compress_response=True,
+    )
 
 
 class IndexHandler(BaseHandler):
 
     async def get(self):
         # TODO Show swagger API or Markdown instead.
-        info = {'diff_types': list(DIFF_ROUTES),
-                'version': web_monitoring_diff.__version__}
+        info = {
+            "diff_types": list(DIFF_ROUTES),
+            "version": web_monitoring_diff.__version__,
+        }
         self.write(info)
 
 
@@ -523,7 +509,6 @@ class HealthCheckHandler(BaseHandler):
         # TODO Include more information about health here.
         # The 200 repsonse code with an empty object is just a liveness check.
         self.write({})
-
 
 
 def start_app(port):
@@ -540,7 +525,7 @@ def start_app(port):
         The port to listen on.
     """
     app = make_app()
-    print(f'Starting server on port {port}')
+    print(f"Starting server on port {port}")
     app.listen(port)
     with Signal((signal.SIGINT, signal.SIGTERM), app.handle_signal):
         tornado.ioloop.IOLoop.current().start()
@@ -551,11 +536,11 @@ def cli():
     Start the diff server from the CLI. This will parse the current process's
     arguments, start an event loop, and begin serving.
     """
-    parser = ArgumentParser(description='Start a diffing server.')
-    parser.add_argument('--version', action='store_true',
-                        help='Show version information')
-    parser.add_argument('--port', type=int, default=8888,
-                        help='Port to listen on')
+    parser = ArgumentParser(description="Start a diffing server.")
+    parser.add_argument(
+        "--version", action="store_true", help="Show version information"
+    )
+    parser.add_argument("--port", type=int, default=8888, help="Port to listen on")
     arguments = parser.parse_args()
 
     if arguments.version:
@@ -568,5 +553,5 @@ def cli():
     start_app(arguments.port)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -201,7 +201,7 @@ class DiffServer(tornado.web.Application):
         super().__init__(handlers, **settings)
         self.terminating = False
         self.server = None
-        self._executor_manager = None  
+        self._executor_manager = None
 
     @property
     def executor_manager(self):
@@ -245,6 +245,7 @@ class DiffServer(tornado.web.Application):
                 sys.exit(1)
 
         loop.add_callback_from_signal(shutdown_and_stop)
+
 
 class BaseHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
@@ -328,7 +329,9 @@ class DiffHandler(BaseHandler):
             )
         except DiffPoolError:
             if not self.application.executor_manager.restart_on_fail:
-                tornado.ioloop.IOLoop.current().add_callback(self.application.quit, code=10)
+                tornado.ioloop.IOLoop.current().add_callback(
+                    self.application.quit, code=10
+                )
             raise
 
     async def fetch_diffable_content(self, url, expected_hash, query_params):
@@ -354,11 +357,15 @@ class DiffHandler(BaseHandler):
                     url, headers=headers, validate_cert=VALIDATE_TARGET_CERTIFICATES
                 )
             except (tornado.httpclient.HTTPError, CurlError) as error:
-                if isinstance(error, tornado.httpclient.HTTPError) and error.response and error.response.headers.get("Memento-Datetime"):
+                if (
+                    isinstance(error, tornado.httpclient.HTTPError)
+                    and error.response
+                    and error.response.headers.get("Memento-Datetime")
+                ):
                     response = error.response
-                else: 
+                else:
                     status_code = 502
-                    if getattr(error, 'code', 0) == 599:
+                    if getattr(error, "code", 0) == 599:
                         status_code = 504
                         if "Maximum file size" in str(error):
                             status_code = 502
@@ -368,8 +375,9 @@ class DiffHandler(BaseHandler):
 
         if response and expected_hash:
             if hashlib.sha256(response.body).hexdigest() != expected_hash:
-                raise PublicError(502, f'hash mismatch for "{url}"') 
+                raise PublicError(502, f'hash mismatch for "{url}"')
         return response
+
 
 def _extract_encoding(headers, content):
     encoding = None
@@ -473,7 +481,7 @@ def caller(func, a, b, **query_params):
     sig = inspect.signature(func)
 
     raise_if_binary = not query_params.get("ignore_decoding_errors", False)
-    
+
     try:
         if "a_text" in sig.parameters:
             query_params.setdefault(

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -24,6 +24,7 @@ from .mock_http import MockResponse
 from .. import basic_diffs, html_render_diff, html_links_diff
 from ..exceptions import UndiffableContentError, UndecodableContentError
 from ..utils import shutdown_executor_in_loop, Signal
+from .executor import DiffExecutorManager, DiffPoolError
 
 # Where possible, use cchardet (or faust-cchardet) for performance.
 # Unfortunately these aren't supported in the latest Python vesions, so we also
@@ -186,66 +187,51 @@ def initialize_diff_worker():
 class DiffServer(tornado.web.Application):
     terminating = False
     server = None
+    executor_manager = None
 
     def listen(self, port, address='', **kwargs):
+        self.executor_manager = DiffExecutorManager(
+            parallelism=DIFFER_PARALLELISM,
+            max_diffs=MAX_DIFFS_PER_WORKER,
+            initializer=initialize_diff_worker,
+            restart_on_fail=RESTART_BROKEN_DIFFER
+        )
         self.server = super().listen(port, address, **kwargs)
         return self.server
 
     async def shutdown(self, immediate=False):
-        """
-        Shut down the server as gracefully as possible. If `immediate` is True,
-        the server will kill any in-progress diff processes immediately.
-        Otherwise, diffs are allowed to try and finish.
-        """
         self.terminating = True
-        if self.server:
+        if self.server: 
             self.server.stop()
-        await self.shutdown_differs(immediate)
-        if self.server:
+        if self.executor_manager: 
+            await self.executor_manager.shutdown(immediate)
+        if self.server: 
             await self.server.close_all_connections()
-
-    async def shutdown_differs(self, immediate=False):
-        """Stop all child processes used for running diffs."""
-        differs = self.settings.get('diff_executor')
-        if differs:
-            if immediate:
-                # NOTE: this might be fragile since we are grabbing a private
-                # attribute. One alternative is to use psutil to find all child
-                # pids and indiscriminately kill them, but that has its own
-                # issues.
-                for child in differs._processes.values():
-                    child.kill()
-            else:
-                await shutdown_executor_in_loop(differs)
 
     async def quit(self, immediate=False, code=0):
         await self.shutdown(immediate=immediate)
         tornado.ioloop.IOLoop.current().stop()
-        if code:
-            sys.exit(code)
+        if code: sys.exit(code)
 
     def handle_signal(self, signal_type, frame):
-        """Handle a signal by shutting down the application and IO loop."""
+        """Handle OS signals by shutting down the application."""
         loop = tornado.ioloop.IOLoop.current()
 
         async def shutdown_and_stop():
             try:
                 immediate = self.terminating
-                method = 'immediately' if immediate else 'gracefully'
-                print(f'Shutting down server {method}...')
+                print(f'Shutting down server {"immediately" if immediate else "gracefully"}...')
                 await self.shutdown(immediate=immediate)
                 loop.stop()
-                print('Shutdown complete.')
             except Exception:
-                logger.exception('Failed to gracefully stop server!')
+                logger.exception('Failed to stop server!')
                 sys.exit(1)
 
         loop.add_callback_from_signal(shutdown_and_stop)
 
-
 class BaseHandler(tornado.web.RequestHandler):
-
     def set_default_headers(self):
+        
         if access_control_allow_origin_header is not None:
             if 'allowed_origins' not in self.settings:
                 self.settings['allowed_origins'] = \
@@ -260,344 +246,133 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header('Access-Control-Allow-Headers', 'x-requested-with')
             self.set_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
 
-    def options(self):
-        # no body
-        self.set_status(204)
-        self.finish()
-
-
 class DiffHandler(BaseHandler):
-    # subclass must define `differs` attribute
+    
 
-    # If query parameters repeat, take last one.
-    # Decode clean query parameters into unicode strings and cache the results.
     @functools.lru_cache()
     def decode_query_params(self):
-        query_params = {k: v[-1].decode() for k, v in
-                        self.request.arguments.items()}
-        return query_params
+        """Decode query parameters into a dictionary."""
+        return {k: v[-1].decode() for k, v in self.request.arguments.items()}
 
-    # Compute our own ETag header values.
     def compute_etag(self):
-        # We're not actually hashing content for this, since that is expensive.
+        """Compute ETag for caching, based on version and query params."""
         validation_bytes = str(
-            web_monitoring_diff.__version__
-            + self.request.path
-            + str(self.decode_query_params())
+            web_monitoring_diff.__version__ + 
+            self.request.path + 
+            str(self.decode_query_params())
         ).encode('utf-8')
-
-        # Uses the "weak validation" directive since we don't guarantee that future
-        # responses for the same diff will be byte-for-byte identical.
-        etag = f'W/"{web_monitoring_diff.utils.hash_content(validation_bytes)}"'
-        return etag
+        return f'W/"{web_monitoring_diff.utils.hash_content(validation_bytes)}"'
 
     async def get(self, differ):
-
-        # Skip a whole bunch of work if possible.
+        # 1. Handle Caching
         self.set_etag_header()
         if self.check_etag_header():
             self.set_status(304)
             self.finish()
             return
 
-        # Find the diffing function registered with the name given by `differ`.
+        # 2. Find the differ function
         try:
             func = self.differs[differ]
         except KeyError:
-            raise PublicError(404, f'Unknown diffing method: `{differ}`. '
-                                   f'You can get a list of '
-                                   f'supported differs from '
-                                   f'the `/` endpoint.')
+            raise PublicError(404, f'Unknown diffing method: `{differ}`.')
 
         query_params = self.decode_query_params()
-        # The logic here is a bit tortured in order to allow one or both URLs
-        # to be local files, while still optimizing the common case of two
-        # remote URLs that we want to fetch in parallel.
         try:
             urls = {param: query_params.pop(param) for param in ('a', 'b')}
         except KeyError:
-            raise PublicError(400,
-                              'Malformed request. You must provide a URL '
-                              'as the value for both `a` and `b` query '
-                              'parameters.')
+            raise PublicError(400, 'Provide a URL for both `a` and `b`.')
 
-        # TODO: Add caching of fetched URIs.
-        requests = [self.fetch_diffable_content(url,
-                                                query_params.pop(f'{param}_hash', None),
-                                                query_params)
+        # 3. Parallel Download 
+        requests = [self.fetch_diffable_content(url, query_params.pop(f'{param}_hash', None), query_params)
                     for param, url in urls.items()]
         content = await asyncio.gather(*requests)
 
-        # Pass the bytes and any remaining args to the diffing function.
+        # 4. Delegate to Manager 
         res = await self.diff(func, content[0], content[1], query_params)
+        
+        # 5. Final Response Formatting
         res['version'] = web_monitoring_diff.__version__
-        # Echo the client's request unless the differ func has specified
-        # somethine else.
         res.setdefault('type', differ)
         self.write(res)
 
+    async def diff(self, func, a, b, params, tries=2):
+        """Delegates work to the manager and handles unrecoverable pool failures."""
+        try:
+            return await self.application.executor_manager.run_diff(
+                caller, func, a, b, params, tries
+            )
+        except DiffPoolError:
+          
+            tornado.ioloop.IOLoop.current().add_callback(
+                self.application.quit, code=10)
+            raise
+
     async def fetch_diffable_content(self, url, expected_hash, query_params):
-        """
-        Fetch and validate a content to diff from a given URL.
-        """
+        """Fetch content with full error handling and protocol support."""
         response = None
 
-        # For testing convenience, support file:// URLs in development.
         if url.startswith('file://'):
             if os.environ.get('WEB_MONITORING_APP_ENV') == 'production':
-                raise PublicError(403, 'Local files cannot be used in '
-                                       'production environment.')
-
+                raise PublicError(403, 'Local files forbidden in production.')
             with open(url[7:], 'rb') as f:
-                body = f.read()
-                response = MockResponse(url, body)
-        # Only support HTTP(S) URLs.
-        elif not url.startswith('http://') and not url.startswith('https://'):
-            raise PublicError(400,
-                              f'URL must use HTTP or HTTPS protocol: "{url}"',
-                              'Invalid URL for upstream content',
-                              extra={'url': url})
+                response = MockResponse(url, f.read())
+        
+        elif not url.startswith(('http://', 'https://')):
+            raise PublicError(400, f'URL must use HTTP or HTTPS: "{url}"')
+        
         else:
-            # Include request headers defined by the query param
-            # `pass_headers=HEADER_NAMES` in the upstream request. This is
-            # useful for passing data like cookie headers. HEADER_NAMES is a
-            # comma-separated list of HTTP header names.
+            # Handle header passing 
             headers = {}
             header_keys = query_params.get('pass_headers')
             if header_keys:
-                for header_key in header_keys.split(','):
-                    header_key = header_key.strip()
-                    header_value = self.request.headers.get(header_key)
-                    if header_value:
-                        headers[header_key] = header_value
+                for key in header_keys.split(','):
+                    val = self.request.headers.get(key.strip())
+                    if val: headers[key.strip()] = val
 
             try:
                 client = get_http_client()
-                response = await client.fetch(url, headers=headers,
+                response = await client.fetch(url, headers=headers, 
                                               validate_cert=VALIDATE_TARGET_CERTIFICATES)
             except ValueError as error:
                 raise PublicError(400, str(error))
-            # Only raised by the simple client and not by the cURL client.
             except OSError as error:
-                raise PublicError(502,
-                                  f'Could not fetch "{url}": {error}',
-                                  'Could not fetch upstream content',
-                                  extra={'url': url, 'cause': str(error)})
-
-            # --- SIMPLE CLIENT ERRORS ----------------------------------------
+                raise PublicError(502, f'Fetch error for "{url}": {error}')
+            
+            # --- DETAILED ERROR HANDLING ---
             except tornado.simple_httpclient.HTTPTimeoutError:
-                raise PublicError(504,
-                                  f'Timed out while fetching "{url}"',
-                                  'Could not fetch upstream content',
-                                  extra={'url': url})
+                raise PublicError(504, f'Timed out fetching "{url}"')
             except tornado.simple_httpclient.HTTPStreamClosedError:
-                # Unfortunately we get pretty ambiguous info if the connection
-                # was closed because we exceeded the max size. :(
-                message = f'The connection was closed while fetching "{url}"'
-                if client.max_body_size:
-                    message += (f' -- this may have been caused by a large '
-                                f'response (the maximum diffable response is '
-                                f'{client.max_body_size} bytes)')
-                raise PublicError(502,
-                                  message,
-                                  'Connection closed while fetching upstream',
-                                  extra={'url': url,
-                                         'max_size': client.max_body_size})
-
-            # --- CURL CLIENT ERRORS ------------------------------------------
+                msg = f'Connection closed for "{url}"'
+                if getattr(client, 'max_body_size', None):
+                    msg += f' (Response might exceed {client.max_body_size} bytes)'
+                raise PublicError(502, msg)
             except CurlError as error:
-                # Documentation for cURL error codes:
-                #   https://curl.haxx.se/libcurl/c/libcurl-errors.html
-                # PyCurl has constants named `E_*` vs. libcurl's `CURLE_*`
                 if error.errno == pycurl.E_URL_MALFORMAT:
-                    raise PublicError(400,
-                                      str(error),
-                                      'Invalid URL for cURL',
-                                      extra={'url': url})
-                # TODO: raise a nicer error from LimitedCurlAsyncHTTPClient
+                    raise PublicError(400, str(error))
                 elif error.errno == pycurl.E_FILESIZE_EXCEEDED:
-                    raise PublicError(502,
-                                      f'Upstream response too big for "{url}"'
-                                      f'(max: {client.max_body_size} bytes)',
-                                      'Upstream content too big',
-                                      extra={'url': url,
-                                             'max_size': client.max_body_size})
-                elif (error.errno == pycurl.E_COULDNT_RESOLVE_PROXY
-                      or error.errno == pycurl.E_COULDNT_CONNECT
-                      or error.errno == 8  # E_WEIRD_SERVER_REPLY
-                      or error.errno == pycurl.E_REMOTE_ACCESS_DENIED
-                      or error.errno == pycurl.E_HTTP2):
-                    raise PublicError(502,
-                                      f'Could not fetch "{url}": {error}',
-                                      'Could not fetch upstream content',
-                                      extra={'url': url, 'cause': str(error)})
+                    raise PublicError(502, f'File too large for "{url}"')
+                elif error.errno in (pycurl.E_COULDNT_RESOLVE_PROXY, pycurl.E_COULDNT_CONNECT):
+                    raise PublicError(502, f'Connection failed for "{url}"')
                 elif error.errno == pycurl.E_OPERATION_TIMEDOUT:
-                    raise PublicError(504,
-                                      f'Timed out while fetching "{url}"',
-                                      'Could not fetch upstream content',
-                                      extra={'url': url})
+                    raise PublicError(504, f'Timed out fetching "{url}"')
                 else:
-                    raise PublicError(502,
-                                      f'Unknown error fetching "{url}"',
-                                      f'Unknown error fetching upstream content: {error}',
-                                      extra={'url': url})
-
-            # --- COMMON ERRORS SUPPORTED BY ALL CLIENTS ----------------------
+                    raise PublicError(502, f'Unknown cURL error fetching "{url}"')
             except tornado.httpclient.HTTPError as error:
-                # If the response is actually coming from a web archive,
-                # allow error codes. The Memento-Datetime header indicates
-                # the response is an archived one, and not an actual failure
-                # to respond with the desired content.
-                if error.response is not None and \
-                        error.response.headers.get('Memento-Datetime') is not None:
+                
+                if error.response and error.response.headers.get('Memento-Datetime'):
                     response = error.response
                 else:
-                    code = error.response and error.response.code
-                    raise PublicError(502,
-                                      (f'Received a {code or "?"} '
-                                       f'status while fetching "{url}": '
-                                       f'{error}'),
-                                      log_message='Could not fetch upstream content',
-                                      extra={'type': 'UPSTREAM_ERROR',
-                                             'url': url,
-                                             'upstream_code': code})
+                    code = error.response.code if error.response else 502
+                    raise PublicError(502, f'Received status {code} from "{url}"')
 
+        # Validate Hash
         if response and expected_hash:
             actual_hash = hashlib.sha256(response.body).hexdigest()
             if actual_hash != expected_hash:
-                raise PublicError(502,
-                                  (f'Fetched content at "{url}" does not '
-                                   f'match hash "{expected_hash}".'),
-                                  log_message='Could not fetch upstream content',
-                                  extra={'type': 'HASH_MISMATCH',
-                                         'url': url,
-                                         'expected_hash': expected_hash,
-                                         'actual_hash': actual_hash})
+                raise PublicError(502, f'Hash mismatch for "{url}"')
 
         return response
-
-    # TODO: we should split out all the management of the executor and diffing
-    # (so this, get_diff_executor, caller, etc.) into a separate object owned
-    # by the server so we don't need weird bits checking the server's
-    # `terminating` state and so that all the parts are grouped together.
-    async def diff(self, func, a, b, params, tries=2):
-        """
-        Actually do a diff between two pieces of content, optionally retrying
-        if the process pool that executes the diff breaks.
-        """
-        reset = False
-        if MAX_DIFFS_PER_WORKER and self.settings.get('remaining_diffs_for_executor', 0) <= 0:
-            reset = True
-            self.settings['remaining_diffs_for_executor'] = MAX_DIFFS_PER_WORKER * DIFFER_PARALLELISM
-        executor = self.get_diff_executor(reset=reset)
-
-        loop = asyncio.get_running_loop()
-        for attempt in range(tries):
-            try:
-                if MAX_DIFFS_PER_WORKER:
-                    self.settings['remaining_diffs_for_executor'] -= 1
-                return await loop.run_in_executor(
-                    executor, functools.partial(caller, func, a, b, **params))
-            except concurrent.futures.process.BrokenProcessPool:
-                if attempt + 1 < tries:
-                    # There could be many diffs happening in parallel, so
-                    # before trying to reset the process pool, make sure other
-                    # parallel diffs haven't already done it. If it's already
-                    # been reset, then we can just go and use the new one.
-                    old_executor, executor = executor, self.get_diff_executor()
-                    if (
-                        executor == old_executor or
-                        (
-                            MAX_DIFFS_PER_WORKER and
-                            self.settings.get('remaining_diffs_for_executor', 0) <= 0
-                        )
-                    ):
-                        self.settings['remaining_diffs_for_executor'] = MAX_DIFFS_PER_WORKER * DIFFER_PARALLELISM
-                        executor = self.get_diff_executor(reset=True)
-                else:
-                    # If we shouldn't allow the server to keep rebuilding the
-                    # differ pool for new requests, schedule a shutdown.
-                    # (*Schuduled* so that current requests have a chance to
-                    # complete with an error.)
-                    if not RESTART_BROKEN_DIFFER:
-                        logger.error('Process pool for diffing has failed too '
-                                     'many times; quitting server...')
-                        tornado.ioloop.IOLoop.current().add_callback(
-                            self.application.quit,
-                            code=10)
-                    raise
-
-    # NOTE: this doesn't do anything async, but if we change it to do so, we
-    # need to add a lock (either asyncio.Lock or tornado.locks.Lock).
-    def get_diff_executor(self, reset=False):
-        if self.application.terminating:
-            raise RuntimeError('Diff executor is being shut down.')
-
-        executor = self.settings.get('diff_executor')
-        if reset or not executor:
-            if executor:
-                try:
-                    # NOTE: we don't need await this; we just want to make sure
-                    # the old executor gets cleaned up.
-                    shutdown_executor_in_loop(executor)
-                except Exception:
-                    pass
-            executor = concurrent.futures.ProcessPoolExecutor(
-                DIFFER_PARALLELISM,
-                initializer=initialize_diff_worker)
-            self.settings['diff_executor'] = executor
-
-        return executor
-
-    def write_error(self, status_code, **kwargs):
-        response = {'code': status_code, 'error': self._reason}
-
-        # Handle errors that are allowed to be public
-        # TODO: this error filtering should probably be in `send_error()`
-        actual_error = 'exc_info' in kwargs and kwargs['exc_info'][1] or None
-        if isinstance(actual_error, (UndiffableContentError, UndecodableContentError)):
-            response['code'] = 422
-            response['error'] = str(actual_error)
-
-        if 'extra' in kwargs:
-            response.update(kwargs['extra'])
-        if isinstance(actual_error, PublicError):
-            response.update(actual_error.extra)
-
-        # Instances of PublicError and tornado.web.HTTPError won't get tracked
-        # by Sentry by default, but we do want to track unexpected, server-side
-        # issues. (Usually a non-HTTPError will have been raised in this case,
-        # but PublicError can be used for special status codes.)
-        if isinstance(actual_error, tornado.web.HTTPError) and response['code'] >= 500:
-            with sentry_sdk.new_scope() as scope:
-                # TODO: this breadcrumb should happen at the start of the
-                # request handler, but we need to test and make sure crumbs are
-                # properly attached to *this* HTTP request and don't bleed over
-                # to others, since Sentry's special support for Tornado has
-                # been dropped.
-                scope.clear_breadcrumbs()
-                headers = dict(self.request.headers)
-                if 'Authorization' in headers:
-                    headers['Authorization'] = '[removed]'
-                scope.add_breadcrumb(category='request', data={
-                    'url': self.request.full_url(),
-                    'method': self.request.method,
-                    'headers': headers,
-                })
-                scope.add_breadcrumb(category='response', data=response)
-                scope.level = 'info'
-                scope.capture_exception(actual_error)
-
-        # Fill in full info if configured to do so
-        if self.settings.get('serve_traceback') and 'exc_info' in kwargs:
-            response['error'] = str(kwargs['exc_info'][1])
-            stack_lines = traceback.format_exception(*kwargs['exc_info'])
-            response['stack'] = ''.join(stack_lines)
-
-        if response['code'] != status_code:
-            self.set_status(response['code'])
-        self.finish(response)
-
 
 def _extract_encoding(headers, content):
     encoding = None
@@ -721,6 +496,18 @@ def caller(func, a, b, **query_params):
     return func(**kwargs)
 
 
+def make_app():
+    """Create the application with proper routes and no dead parameters."""
+    class BoundDiffHandler(DiffHandler):
+        differs = DIFF_ROUTES
+
+    return DiffServer([
+        (r"/healthcheck", HealthCheckHandler),
+        (r"/([A-Za-z0-9_]+)", BoundDiffHandler),
+        (r"/", IndexHandler),
+    ], debug=DEBUG_MODE, compress_response=True)
+
+
 class IndexHandler(BaseHandler):
 
     async def get(self):
@@ -737,20 +524,6 @@ class HealthCheckHandler(BaseHandler):
         # The 200 repsonse code with an empty object is just a liveness check.
         self.write({})
 
-
-def make_app():
-    """
-    Create and return a Tornado application object that serves diffs.
-    """
-    class BoundDiffHandler(DiffHandler):
-        differs = DIFF_ROUTES
-
-    return DiffServer([
-        (r"/healthcheck", HealthCheckHandler),
-        (r"/([A-Za-z0-9_]+)", BoundDiffHandler),
-        (r"/", IndexHandler),
-    ], debug=DEBUG_MODE, compress_response=True,
-       diff_executor=None)
 
 
 def start_app(port):

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -201,12 +201,18 @@ class DiffServer(tornado.web.Application):
         super().__init__(handlers, **settings)
         self.terminating = False
         self.server = None
-        self.executor_manager = DiffExecutorManager(
-            parallelism=DIFFER_PARALLELISM,
-            max_diffs=MAX_DIFFS_PER_WORKER,
-            initializer=initialize_diff_worker,
-            restart_on_fail=RESTART_BROKEN_DIFFER,
-        )
+        self._executor_manager = None  
+
+    @property
+    def executor_manager(self):
+        if self._executor_manager is None:
+            self._executor_manager = DiffExecutorManager(
+                parallelism=DIFFER_PARALLELISM,
+                max_diffs=MAX_DIFFS_PER_WORKER,
+                initializer=initialize_diff_worker,
+                restart_on_fail=RESTART_BROKEN_DIFFER,
+            )
+        return self._executor_manager
 
     def listen(self, port, address="", **kwargs):
         self.server = super().listen(port, address, **kwargs)
@@ -216,8 +222,8 @@ class DiffServer(tornado.web.Application):
         self.terminating = True
         if self.server:
             self.server.stop()
-        if self.executor_manager:
-            await self.executor_manager.shutdown(immediate)
+        if self._executor_manager:
+            await self._executor_manager.shutdown(immediate)
         if self.server:
             await self.server.close_all_connections()
 
@@ -240,7 +246,6 @@ class DiffServer(tornado.web.Application):
 
         loop.add_callback_from_signal(shutdown_and_stop)
 
-
 class BaseHandler(tornado.web.RequestHandler):
     def set_default_headers(self):
 
@@ -262,16 +267,13 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
 
     def write_error(self, status_code, **kwargs):
-        """Override Tornado's default HTML error page with a JSON response."""
+        """Force Tornado to return JSON on errors instead of HTML pages."""
         self.set_header("Content-Type", "application/json")
-
         response = {"error": self._reason, "code": status_code}
-
         if "exc_info" in kwargs:
             exc = kwargs["exc_info"][1]
             if isinstance(exc, PublicError) and exc.extra:
                 response.update(exc.extra)
-
         self.finish(json.dumps(response))
 
 
@@ -325,7 +327,8 @@ class DiffHandler(BaseHandler):
                 caller, func, a, b, params, tries
             )
         except DiffPoolError:
-            tornado.ioloop.IOLoop.current().add_callback(self.application.quit, code=10)
+            if not self.application.executor_manager.restart_on_fail:
+                tornado.ioloop.IOLoop.current().add_callback(self.application.quit, code=10)
             raise
 
     async def fetch_diffable_content(self, url, expected_hash, query_params):
@@ -351,21 +354,22 @@ class DiffHandler(BaseHandler):
                     url, headers=headers, validate_cert=VALIDATE_TARGET_CERTIFICATES
                 )
             except (tornado.httpclient.HTTPError, CurlError) as error:
-                if (
-                    isinstance(error, tornado.httpclient.HTTPError)
-                    and error.response
-                    and error.response.headers.get("Memento-Datetime")
-                ):
+                if isinstance(error, tornado.httpclient.HTTPError) and error.response and error.response.headers.get("Memento-Datetime"):
                     response = error.response
-                else:
-                    status_code = 504 if getattr(error, "code", 0) == 599 else 502
+                else: 
+                    status_code = 502
+                    if getattr(error, 'code', 0) == 599:
+                        status_code = 504
+                        if "Maximum file size" in str(error):
+                            status_code = 502
                     raise PublicError(status_code, f'Fetch error for "{url}": {error}')
+            except OSError as error:
+                raise PublicError(502, f'Connection error for "{url}": {error}')
 
         if response and expected_hash:
             if hashlib.sha256(response.body).hexdigest() != expected_hash:
-                raise PublicError(502, f'Hash mismatch for "{url}"')
+                raise PublicError(502, f'hash mismatch for "{url}"') 
         return response
-
 
 def _extract_encoding(headers, content):
     encoding = None
@@ -469,14 +473,18 @@ def caller(func, a, b, **query_params):
     sig = inspect.signature(func)
 
     raise_if_binary = not query_params.get("ignore_decoding_errors", False)
-    if "a_text" in sig.parameters:
-        query_params.setdefault(
-            "a_text", _decode_body(a, "a", raise_if_binary=raise_if_binary)
-        )
-    if "b_text" in sig.parameters:
-        query_params.setdefault(
-            "b_text", _decode_body(b, "b", raise_if_binary=raise_if_binary)
-        )
+    
+    try:
+        if "a_text" in sig.parameters:
+            query_params.setdefault(
+                "a_text", _decode_body(a, "a", raise_if_binary=raise_if_binary)
+            )
+        if "b_text" in sig.parameters:
+            query_params.setdefault(
+                "b_text", _decode_body(b, "b", raise_if_binary=raise_if_binary)
+            )
+    except UndecodableContentError as e:
+        raise PublicError(422, str(e))
 
     kwargs = dict()
     for name, param in sig.parameters.items():

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -23,6 +23,7 @@ from .. import basic_diffs, html_render_diff, html_links_diff
 from ..exceptions import UndecodableContentError
 from ..utils import Signal
 from .executor import DiffExecutorManager, DiffPoolError
+import json
 
 # Where possible, use cchardet (or faust-cchardet) for performance.
 # Unfortunately these aren't supported in the latest Python vesions, so we also
@@ -260,6 +261,19 @@ class BaseHandler(tornado.web.RequestHandler):
             self.set_header("Access-Control-Allow-Headers", "x-requested-with")
             self.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
 
+    def write_error(self, status_code, **kwargs):
+        """Override Tornado's default HTML error page with a JSON response."""
+        self.set_header("Content-Type", "application/json")
+
+        response = {"error": self._reason, "code": status_code}
+
+        if "exc_info" in kwargs:
+            exc = kwargs["exc_info"][1]
+            if isinstance(exc, PublicError) and exc.extra:
+                response.update(exc.extra)
+
+        self.finish(json.dumps(response))
+
 
 class DiffHandler(BaseHandler):
     def get_diff_executor(self, reset=False):
@@ -344,7 +358,9 @@ class DiffHandler(BaseHandler):
                 ):
                     response = error.response
                 else:
-                    raise PublicError(502, f'Fetch error for "{url}": {error}')
+                    status_code = 504 if getattr(error, "code", 0) == 599 else 502
+                    raise PublicError(status_code, f'Fetch error for "{url}": {error}')
+
         if response and expected_hash:
             if hashlib.sha256(response.body).hexdigest() != expected_hash:
                 raise PublicError(502, f'Hash mismatch for "{url}"')

--- a/web_monitoring_diff/tests/test_server_exc_handling.py
+++ b/web_monitoring_diff/tests/test_server_exc_handling.py
@@ -26,10 +26,11 @@ def patch_http_client(**kwargs):
     Create HTTP clients in the diffing server with the specified parameters
     during this patch. Can be a function decorator or context manager.
     """
+
     def get_client():
-        return tornado.httpclient.AsyncHTTPClient(force_instance=True,
-                                                  **kwargs)
-    return patch.object(df, 'get_http_client', get_client)
+        return tornado.httpclient.AsyncHTTPClient(force_instance=True, **kwargs)
+
+    return patch.object(df, "get_http_client", get_client)
 
 
 def mock_http_client(test_func):
@@ -44,9 +45,10 @@ def mock_http_client(test_func):
     >>>    client.respond_to(r'/b', code=500, body='goodbye')
     >>>    self.fetch('/html_source_dmp?a=http://ex.com/a&b=http://ex.com/b')
     """
+
     def new_test_func(*args):
         mock = MockAsyncHttpClient()
-        with patch.object(df, 'get_http_client', return_value=mock):
+        with patch.object(df, "get_http_client", return_value=mock):
             return test_func(*args, mock)
 
     return new_test_func
@@ -58,19 +60,19 @@ class DiffingServerTestCase(AsyncHTTPTestCase):
         return df.make_app()
 
     def json_check(self, response):
-        json_header = response.headers.get('Content-Type').split(';')
-        self.assertEqual(json_header[0], 'application/json')
+        json_header = response.headers.get("Content-Type").split(";")
+        self.assertEqual(json_header[0], "application/json")
 
         json_response = json.loads(response.body)
-        self.assertTrue(isinstance(json_response['code'], int))
-        self.assertTrue(isinstance(json_response['error'], str))
+        self.assertTrue(isinstance(json_response["code"], int))
+        self.assertTrue(isinstance(json_response["error"], str))
 
 
 class DiffingServerIndexTest(DiffingServerTestCase):
     def test_version(self):
-        response = self.fetch('/')
+        response = self.fetch("/")
         json_response = json.loads(response.body)
-        assert json_response['version'] == web_monitoring_diff.__version__
+        assert json_response["version"] == web_monitoring_diff.__version__
 
 
 class DiffingServerLocalHandlingTest(DiffingServerTestCase):
@@ -78,16 +80,18 @@ class DiffingServerLocalHandlingTest(DiffingServerTestCase):
     @mock_http_client
     def test_one_local(self, client):
         with tempfile.NamedTemporaryFile() as a:
-            client.respond_to(r'example.org', body='Whatever')
-            response = self.fetch('/identical_bytes?'
-                                  f'a=file://{a.name}&b=https://example.org')
+            client.respond_to(r"example.org", body="Whatever")
+            response = self.fetch(
+                "/identical_bytes?" f"a=file://{a.name}&b=https://example.org"
+            )
             self.assertEqual(response.code, 200)
 
     def test_both_local(self):
         with tempfile.NamedTemporaryFile() as a:
             with tempfile.NamedTemporaryFile() as b:
-                response = self.fetch('/identical_bytes?'
-                                      f'a=file://{a.name}&b=file://{b.name}')
+                response = self.fetch(
+                    "/identical_bytes?" f"a=file://{a.name}&b=file://{b.name}"
+                )
                 self.assertEqual(response.code, 200)
 
 
@@ -95,29 +99,36 @@ class DiffingServerEtagTest(DiffingServerTestCase):
     def test_etag_validation(self):
         with tempfile.NamedTemporaryFile() as a:
             with tempfile.NamedTemporaryFile() as b:
-                cold_response = self.fetch('/html_token?format=json&include=all&'
-                        f'a=file://{a.name}&b=file://{b.name}')
+                cold_response = self.fetch(
+                    "/html_token?format=json&include=all&"
+                    f"a=file://{a.name}&b=file://{b.name}"
+                )
                 self.assertEqual(cold_response.code, 200)
 
-                etag = cold_response.headers.get('Etag')
+                etag = cold_response.headers.get("Etag")
 
-                warm_response = self.fetch('/html_token?format=json&include=all&'
-                        f'a=file://{a.name}&b=file://{b.name}',
-                                           headers={'If-None-Match': etag,
-                                           'Accept': 'application/json'})
+                warm_response = self.fetch(
+                    "/html_token?format=json&include=all&"
+                    f"a=file://{a.name}&b=file://{b.name}",
+                    headers={"If-None-Match": etag, "Accept": "application/json"},
+                )
                 self.assertEqual(warm_response.code, 304)
 
-                mismatch_response = self.fetch('/html_token?format=json&include=all&'
-                        f'a=file://{a.name}&b=file://{b.name}',
-                                           headers={'If-None-Match': 'Stale Value',
-                                           'Accept': 'application/json'})
+                mismatch_response = self.fetch(
+                    "/html_token?format=json&include=all&"
+                    f"a=file://{a.name}&b=file://{b.name}",
+                    headers={
+                        "If-None-Match": "Stale Value",
+                        "Accept": "application/json",
+                    },
+                )
                 self.assertEqual(mismatch_response.code, 200)
 
 
 class DiffingServerHealthCheckHandlingTest(DiffingServerTestCase):
 
     def test_healthcheck(self):
-        response = self.fetch('/healthcheck')
+        response = self.fetch("/healthcheck")
         self.assertEqual(response.code, 200)
 
 
@@ -125,132 +136,151 @@ class DiffingServerFetchTest(DiffingServerTestCase):
 
     @mock_http_client
     def test_pass_headers(self, client):
-        client.respond_to(r'/a$')
-        client.respond_to(r'/b$')
+        client.respond_to(r"/a$")
+        client.respond_to(r"/b$")
 
-        self.fetch('/html_source_dmp?'
-                   'pass_headers=Authorization,%20User-Agent&'
-                   'a=https://example.org/a&b=https://example.org/b',
-                   headers={'User-Agent': 'Some Agent',
-                            'Authorization': 'Bearer xyz',
-                            'Accept': 'application/json'})
+        self.fetch(
+            "/html_source_dmp?"
+            "pass_headers=Authorization,%20User-Agent&"
+            "a=https://example.org/a&b=https://example.org/b",
+            headers={
+                "User-Agent": "Some Agent",
+                "Authorization": "Bearer xyz",
+                "Accept": "application/json",
+            },
+        )
 
-        a_headers = client.requests['https://example.org/a'].headers
-        assert a_headers.get('User-Agent') == 'Some Agent'
-        assert a_headers.get('Authorization') == 'Bearer xyz'
-        assert a_headers.get('Accept') != 'application/json'
+        a_headers = client.requests["https://example.org/a"].headers
+        assert a_headers.get("User-Agent") == "Some Agent"
+        assert a_headers.get("Authorization") == "Bearer xyz"
+        assert a_headers.get("Accept") != "application/json"
 
-        b_headers = client.requests['https://example.org/b'].headers
-        assert b_headers.get('User-Agent') == 'Some Agent'
-        assert b_headers.get('Authorization') == 'Bearer xyz'
-        assert b_headers.get('Accept') != 'application/json'
+        b_headers = client.requests["https://example.org/b"].headers
+        assert b_headers.get("User-Agent") == "Some Agent"
+        assert b_headers.get("Authorization") == "Bearer xyz"
+        assert b_headers.get("Accept") != "application/json"
 
 
 class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
 
-    @patch.dict(os.environ, {'WEB_MONITORING_APP_ENV': 'production'})
+    @patch.dict(os.environ, {"WEB_MONITORING_APP_ENV": "production"})
     @mock_http_client
     def test_local_file_disallowed_in_production(self, client):
-        client.respond_to(r'example\.org', body='Whatever')
+        client.respond_to(r"example\.org", body="Whatever")
         with tempfile.NamedTemporaryFile() as a:
-            response = self.fetch('/identical_bytes?'
-                                  f'a=file://{a.name}&b=https://example.org')
+            response = self.fetch(
+                "/identical_bytes?" f"a=file://{a.name}&b=https://example.org"
+            )
             self.assertEqual(response.code, 403)
 
     @mock_http_client
     def test_invalid_url_a_format(self, client):
-        client.respond_to(r'example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all&'
-                              'a=example.org&b=https://example.org')
+        client.respond_to(r"example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all&" "a=example.org&b=https://example.org"
+        )
         self.json_check(response)
         self.assertEqual(response.code, 400)
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     @mock_http_client
     def test_invalid_url_b_format(self, client):
-        client.respond_to(r'example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all&'
-                              'a=https://example.org&b=example.org')
+        client.respond_to(r"example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all&" "a=https://example.org&b=example.org"
+        )
         self.json_check(response)
         self.assertEqual(response.code, 400)
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     @mock_http_client
     def test_invalid_diffing_method(self, client):
-        client.respond_to(r'example\.org', body='Whatever')
-        response = self.fetch('/non_existing?format=json&include=all&'
-                              'a=example.org&b=https://example.org')
+        client.respond_to(r"example\.org", body="Whatever")
+        response = self.fetch(
+            "/non_existing?format=json&include=all&"
+            "a=example.org&b=https://example.org"
+        )
         self.json_check(response)
         self.assertEqual(response.code, 404)
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     @mock_http_client
     def test_missing_url_a(self, client):
-        client.respond_to(r'example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all&'
-                              'b=https://example.org')
+        client.respond_to(r"example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all&" "b=https://example.org"
+        )
         self.json_check(response)
         self.assertEqual(response.code, 400)
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     @mock_http_client
     def test_missing_url_b(self, client):
-        client.respond_to(r'example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all&'
-                              'a=https://example.org')
+        client.respond_to(r"example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all&" "a=https://example.org"
+        )
         self.json_check(response)
         self.assertEqual(response.code, 400)
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     @mock_http_client
     def test_not_reachable_url_a(self, client):
-        client.respond_to(r'/eeexample\.org', error=OSError('Connection error'))
-        client.respond_to(r'/example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all&'
-                              'a=https://eeexample.org&b=https://example.org')
+        client.respond_to(r"/eeexample\.org", error=OSError("Connection error"))
+        client.respond_to(r"/example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all&"
+            "a=https://eeexample.org&b=https://example.org"
+        )
         self.json_check(response)
         self.assertEqual(response.code, 502)
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     @mock_http_client
     def test_not_reachable_url_b(self, client):
-        client.respond_to(r'/eeexample\.org', error=OSError('Connection error'))
-        client.respond_to(r'/example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all&'
-                              'a=https://example.org&b=https://eeexample.org')
+        client.respond_to(r"/eeexample\.org", error=OSError("Connection error"))
+        client.respond_to(r"/example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all&"
+            "a=https://example.org&b=https://eeexample.org"
+        )
         self.json_check(response)
         self.assertEqual(response.code, 502)
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     @patch_http_client(defaults=dict(request_timeout=0.5))
     def test_timeout_upstream(self):
         async def responder(handler):
             await asyncio.sleep(1)
-            handler.write('HELLO!'.encode('utf-8'))
+            handler.write("HELLO!".encode("utf-8"))
 
         with SimpleHttpServer(responder) as server:
-            response = self.fetch('/html_source_dmp?'
-                                  f'a={server.url("/whatever1")}&'
-                                  f'b={server.url("/whatever2")}')
+            response = self.fetch(
+                "/html_source_dmp?"
+                f'a={server.url("/whatever1")}&'
+                f'b={server.url("/whatever2")}'
+            )
             assert response.code == 504
 
     def test_missing_params_caller_func(self):
-        response = MockResponse('http://example.org/', 'Whatever')
+        response = MockResponse("http://example.org/", "Whatever")
         with self.assertRaises(KeyError):
             df.caller(mock_diffing_method, response, response)
 
     @mock_http_client
     def test_a_is_404(self, client):
-        client.respond_to(r'/404', code=404, body='Error 404')
-        client.respond_to(r'/success')
+        client.respond_to(r"/404", code=404, body="Error 404")
+        client.respond_to(r"/success")
 
-        response = self.fetch('/html_token?format=json&include=all'
-                              '&a=http://httpstat.us/404'
-                              '&b=https://example.org/success')
+        response = self.fetch(
+            "/html_token?format=json&include=all"
+            "&a=http://httpstat.us/404"
+            "&b=https://example.org/success"
+        )
         # The error is upstream, but the message should indicate it was a 404.
         self.assertEqual(response.code, 502)
-        assert '404' in json.loads(response.body)['error']
-        self.assertFalse(response.headers.get('Etag'))
+        assert "404" in json.loads(response.body)["error"]
+        self.assertFalse(response.headers.get("Etag"))
         self.json_check(response)
 
     @mock_http_client
@@ -259,17 +289,23 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         If a page has HTTP status != 2xx but comes from a web archive,
         we proceed with diffing.
         """
-        client.respond_to(r'/error$', code=404, headers={'Memento-Datetime': 'Tue Sep 25 2018 03:38:50'})
-        client.respond_to(r'/success$')
+        client.respond_to(
+            r"/error$",
+            code=404,
+            headers={"Memento-Datetime": "Tue Sep 25 2018 03:38:50"},
+        )
+        client.respond_to(r"/success$")
 
-        response = self.fetch('/html_token?format=json&include=all'
-                              '&a=https://archive.org/20180925033850/http://httpstat.us/error'
-                              '&b=https://example.org/success')
+        response = self.fetch(
+            "/html_token?format=json&include=all"
+            "&a=https://archive.org/20180925033850/http://httpstat.us/error"
+            "&b=https://example.org/success"
+        )
 
         self.assertEqual(response.code, 200)
-        assert 'change_count' in json.loads(response.body)
+        assert "change_count" in json.loads(response.body)
 
-    @patch('web_monitoring_diff.server.server.access_control_allow_origin_header', '*')
+    @patch("web_monitoring_diff.server.server.access_control_allow_origin_header", "*")
     @mock_http_client
     def test_check_cors_headers(self, client):
         """
@@ -278,18 +314,23 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         Access-Control-Allow-Origin value equals request Origin header because
         we use setting `access_control_allow_origin_header='*'`.
         """
-        client.respond_to(r'example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all'
-                              '&a=https://example.org&b=https://example.org',
-                              headers={'Accept': 'application/json',
-                                       'Origin': 'http://test.com'})
-        assert response.headers.get('Access-Control-Allow-Origin') == 'http://test.com'
-        assert response.headers.get('Access-Control-Allow-Credentials') == 'true'
-        assert response.headers.get('Access-Control-Allow-Headers') == 'x-requested-with'
-        assert response.headers.get('Access-Control-Allow-Methods') == 'GET, OPTIONS'
+        client.respond_to(r"example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all"
+            "&a=https://example.org&b=https://example.org",
+            headers={"Accept": "application/json", "Origin": "http://test.com"},
+        )
+        assert response.headers.get("Access-Control-Allow-Origin") == "http://test.com"
+        assert response.headers.get("Access-Control-Allow-Credentials") == "true"
+        assert (
+            response.headers.get("Access-Control-Allow-Headers") == "x-requested-with"
+        )
+        assert response.headers.get("Access-Control-Allow-Methods") == "GET, OPTIONS"
 
-    @patch('web_monitoring_diff.server.server.access_control_allow_origin_header',
-           'http://one.com,http://two.com,http://three.com')
+    @patch(
+        "web_monitoring_diff.server.server.access_control_allow_origin_header",
+        "http://one.com,http://two.com,http://three.com",
+    )
     @mock_http_client
     def test_cors_origin_header(self, client):
         """
@@ -299,45 +340,48 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         at all.
         This is necessary for CORS requests with credentials to work properly.
         """
-        client.respond_to(r'example\.org', body='Whatever')
-        response = self.fetch('/html_token?format=json&include=all'
-                              '&a=https://example.org&b=https://example.org',
-                              headers={'Accept': 'application/json',
-                                       'Origin': 'http://two.com'})
-        assert response.headers.get('Access-Control-Allow-Origin') == 'http://two.com'
+        client.respond_to(r"example\.org", body="Whatever")
+        response = self.fetch(
+            "/html_token?format=json&include=all"
+            "&a=https://example.org&b=https://example.org",
+            headers={"Accept": "application/json", "Origin": "http://two.com"},
+        )
+        assert response.headers.get("Access-Control-Allow-Origin") == "http://two.com"
 
     def test_decode_empty_bodies(self):
-        response = mock_tornado_request('empty.txt')
-        df._decode_body(response, 'a')
+        response = mock_tornado_request("empty.txt")
+        df._decode_body(response, "a")
 
     def test_poorly_encoded_content(self):
-        response = mock_tornado_request('poorly_encoded_utf8.txt')
-        df._decode_body(response, 'a')
+        response = mock_tornado_request("poorly_encoded_utf8.txt")
+        df._decode_body(response, "a")
 
     def test_undecodable_content(self):
-        response = mock_tornado_request('simple.pdf')
+        response = mock_tornado_request("simple.pdf")
         with self.assertRaises(UndecodableContentError):
-            df._decode_body(response, 'a')
+            df._decode_body(response, "a")
 
     def test_fetch_undecodable_content(self):
-        response = self.fetch('/html_source_dmp?format=json&'
-                              f'a=file://{fixture_path("poorly_encoded_utf8.txt")}&'
-                              f'b=file://{fixture_path("simple.pdf")}')
+        response = self.fetch(
+            "/html_source_dmp?format=json&"
+            f'a=file://{fixture_path("poorly_encoded_utf8.txt")}&'
+            f'b=file://{fixture_path("simple.pdf")}'
+        )
         self.json_check(response)
         assert response.code == 422
-        self.assertFalse(response.headers.get('Etag'))
+        self.assertFalse(response.headers.get("Etag"))
 
     def test_treats_unknown_encoding_as_ascii(self):
-        response = mock_tornado_request('unknown_encoding.html')
-        df._decode_body(response, 'a')
+        response = mock_tornado_request("unknown_encoding.html")
+        df._decode_body(response, "a")
 
     def test_extract_encoding_bad_headers(self):
-        headers = {'Content-Type': '  text/html; charset=iso-8859-7'}
-        assert df._extract_encoding(headers, b'') == 'iso-8859-7'
-        headers = {'Content-Type': 'text/xhtml;CHARSET=iso-8859-5 '}
-        assert df._extract_encoding(headers, b'') == 'iso-8859-5'
-        headers = {'Content-Type': '\x94Invalid\x0b'}
-        assert df._extract_encoding(headers, b'') == 'utf-8'
+        headers = {"Content-Type": "  text/html; charset=iso-8859-7"}
+        assert df._extract_encoding(headers, b"") == "iso-8859-7"
+        headers = {"Content-Type": "text/xhtml;CHARSET=iso-8859-5 "}
+        assert df._extract_encoding(headers, b"") == "iso-8859-5"
+        headers = {"Content-Type": "\x94Invalid\x0b"}
+        assert df._extract_encoding(headers, b"") == "utf-8"
 
     def test_extract_encoding_from_body(self):
         # Polish content without any content-type headers or meta tag.
@@ -345,56 +389,66 @@ class DiffingServerExceptionHandlingTest(DiffingServerTestCase):
         body = """<html><head><title>TITLE</title></head>
          <i>И така, какво да направите, за да видите българските букви в текстовете?</i>
          Четенето не е задължително, но може да обясни много.
-         <body></body>""".encode('iso-8859-5')
-        assert df._extract_encoding(headers, body) == 'iso-8859-5'
+         <body></body>""".encode("iso-8859-5")
+        assert df._extract_encoding(headers, body) == "iso-8859-5"
 
     def test_diff_content_with_null_bytes(self):
-        response = self.fetch('/html_source_dmp?format=json&'
-                              f'a=file://{fixture_path("has_null_byte.txt")}&'
-                              f'b=file://{fixture_path("has_null_byte.txt")}')
+        response = self.fetch(
+            "/html_source_dmp?format=json&"
+            f'a=file://{fixture_path("has_null_byte.txt")}&'
+            f'b=file://{fixture_path("has_null_byte.txt")}'
+        )
         assert response.code == 200
 
     def test_validates_good_hashes(self):
-        response = self.fetch('/html_source_dmp?format=json&'
-                              f'a=file://{fixture_path("empty.txt")}&'
-                              'a_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&'
-                              f'b=file://{fixture_path("empty.txt")}&'
-                              'b_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+        response = self.fetch(
+            "/html_source_dmp?format=json&"
+            f'a=file://{fixture_path("empty.txt")}&'
+            "a_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&"
+            f'b=file://{fixture_path("empty.txt")}&'
+            "b_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
         assert response.code == 200
 
     def test_validates_bad_hashes(self):
-        response = self.fetch('/html_source_dmp?format=json&'
-                              f'a=file://{fixture_path("empty.txt")}&'
-                              'a_hash=f3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&'
-                              f'b=file://{fixture_path("empty.txt")}&'
-                              'b_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+        response = self.fetch(
+            "/html_source_dmp?format=json&"
+            f'a=file://{fixture_path("empty.txt")}&'
+            "a_hash=f3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855&"
+            f'b=file://{fixture_path("empty.txt")}&'
+            "b_hash=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        )
         assert response.code == 502
-        assert 'hash' in json.loads(response.body)['error']
+        assert "hash" in json.loads(response.body)["error"]
 
 
 class DiffingServerResponseSizeTest(DiffingServerTestCase):
     @patch_http_client(max_body_size=100 * 1024)
     def test_succeeds_if_response_is_small_enough(self):
         async def responder(handler):
-            text = (80 * 1024) * 'x'
-            handler.write(text.encode('utf-8'))
+            text = (80 * 1024) * "x"
+            handler.write(text.encode("utf-8"))
 
         with SimpleHttpServer(responder) as server:
-            response = self.fetch('/html_source_dmp?'
-                                  f'a={server.url("/whatever1")}&'
-                                  f'b={server.url("/whatever2")}')
+            response = self.fetch(
+                "/html_source_dmp?"
+                f'a={server.url("/whatever1")}&'
+                f'b={server.url("/whatever2")}'
+            )
             assert response.code == 200
 
     @patch_http_client(max_body_size=100 * 1024)
     def test_stops_if_response_is_too_big(self):
         async def responder(handler):
-            text = (110 * 1024) * 'x'
-            handler.write(text.encode('utf-8'))
+            text = (110 * 1024) * "x"
+            handler.write(text.encode("utf-8"))
 
         with SimpleHttpServer(responder) as server:
-            response = self.fetch('/html_source_dmp?'
-                                  f'a={server.url("/whatever1")}&'
-                                  f'b={server.url("/whatever2")}')
+            response = self.fetch(
+                "/html_source_dmp?"
+                f'a={server.url("/whatever1")}&'
+                f'b={server.url("/whatever2")}'
+            )
             assert response.code == 502
 
     @patch_http_client(max_body_size=100 * 1024)
@@ -404,16 +458,18 @@ class DiffingServerResponseSizeTest(DiffingServerTestCase):
             # content than we said we would, so we have to subvert it by
             # flushing the headers and resetting its expectations before
             # writing our output.
-            handler.set_header('Content-Length', '1024')
+            handler.set_header("Content-Length", "1024")
             handler.flush()
             handler.request.connection._expected_content_remaining = None
-            text = (110 * 1024) * 'x'
-            handler.write(text.encode('utf-8'))
+            text = (110 * 1024) * "x"
+            handler.write(text.encode("utf-8"))
 
         with SimpleHttpServer(responder) as server:
-            response = self.fetch('/html_source_dmp?'
-                                  f'a={server.url("/whatever1")}&'
-                                  f'b={server.url("/whatever2")}')
+            response = self.fetch(
+                "/html_source_dmp?"
+                f'a={server.url("/whatever1")}&'
+                f'b={server.url("/whatever2")}'
+            )
             # Even though the response was longer than the max_body_size,
             # the client should have stopped reading when it hit the number
             # of bytes set in the Content-Length, header, which is less
@@ -425,12 +481,13 @@ class DiffingServerResponseSizeTest(DiffingServerTestCase):
             # <Content-Length> bytes long (all our chars are basic ASCII
             # in this case, so len(bytes) == len(characters)).
             result = json.loads(response.body)
-            assert result['change_count'] == 0
-            assert len(result['diff'][0][1]) == 1024
+            assert result["change_count"] == 0
+            assert len(result["diff"][0][1]) == 1024
 
 
 class BrokenProcessPoolExecutor(concurrent.futures.Executor):
     "Fake process pool that only raises BrokenProcessPool exceptions."
+
     submit_count = 0
 
     def __init__(max_workers=None, mp_context=None, initializer=None, initargs=()):
@@ -443,9 +500,7 @@ class BrokenProcessPoolExecutor(concurrent.futures.Executor):
 
     async def failing_task(self):
         await asyncio.sleep(0.005)
-        raise BrokenProcessPool(
-            'This pool is broken, yo'
-        )
+        raise BrokenProcessPool("This pool is broken, yo")
 
 
 class ExecutionPoolTestCase(DiffingServerTestCase):
@@ -458,7 +513,9 @@ class ExecutionPoolTestCase(DiffingServerTestCase):
         # Get a custom executor that will always fail the first time, but get
         # a real one that will succeed afterward.
         did_get_executor = False
-        def get_executor(self, reset=False):
+
+        # Make async and use force_reset parameter
+        async def get_executor(self, force_reset=False):
             nonlocal did_get_executor
             if did_get_executor:
                 return ProcessPoolExecutor(1)
@@ -466,23 +523,28 @@ class ExecutionPoolTestCase(DiffingServerTestCase):
                 did_get_executor = True
                 return BrokenProcessPoolExecutor()
 
-        with patch.object(df.DiffHandler, 'get_diff_executor', get_executor):
-            response = self.fetch('/html_source_dmp?format=json&'
-                                  f'a=file://{fixture_path("empty.txt")}&'
-                                  f'b=file://{fixture_path("empty.txt")}')
+        # Patch DiffExecutorManager instead of DiffHandler
+        with patch.object(df.DiffExecutorManager, "get_executor", get_executor):
+            response = self.fetch(
+                "/html_source_dmp?format=json&"
+                f'a=file://{fixture_path("empty.txt")}&'
+                f'b=file://{fixture_path("empty.txt")}'
+            )
             assert response.code == 200
             assert did_get_executor == True
 
     @patch.object(df.DiffServer, "quit")
     def test_diff_returns_error_if_process_pool_repeatedly_breaks(self, _):
-        # Set a custom executor that will always fail.
-        def get_executor(self, reset=False):
+        # Make async and use force_reset parameter
+        async def get_executor(self, force_reset=False):
             return BrokenProcessPoolExecutor()
 
-        with patch.object(df.DiffHandler, 'get_diff_executor', get_executor):
-            response = self.fetch('/html_source_dmp?format=json&'
-                                  f'a=file://{fixture_path("empty.txt")}&'
-                                  f'b=file://{fixture_path("empty.txt")}')
+        with patch.object(df.DiffExecutorManager, "get_executor", get_executor):
+            response = self.fetch(
+                "/html_source_dmp?format=json&"
+                f'a=file://{fixture_path("empty.txt")}&'
+                f'b=file://{fixture_path("empty.txt")}'
+            )
             self.json_check(response)
             assert response.code == 500
 
@@ -497,22 +559,27 @@ class ExecutionPoolTestCase(DiffingServerTestCase):
         executor_resets = 0
         good_executor = ProcessPoolExecutor(1)
         bad_executor = BrokenProcessPoolExecutor()
-        def get_executor(self, reset=False):
+
+        async def get_executor(self, force_reset=False):
             nonlocal executor_resets
-            if reset:
+            if force_reset:
                 executor_resets += 1
             if executor_resets > 0:
                 return good_executor
             else:
                 return bad_executor
 
-        with patch.object(df.DiffHandler, 'get_diff_executor', get_executor):
-            one = self.fetch_async('/html_source_dmp?format=json&'
-                                   f'a=file://{fixture_path("empty.txt")}&'
-                                   f'b=file://{fixture_path("empty.txt")}')
-            two = self.fetch_async('/html_source_dmp?format=json&'
-                                   f'a=file://{fixture_path("empty.txt")}&'
-                                   f'b=file://{fixture_path("empty.txt")}')
+        with patch.object(df.DiffExecutorManager, "get_executor", get_executor):
+            one = self.fetch_async(
+                "/html_source_dmp?format=json&"
+                f'a=file://{fixture_path("empty.txt")}&'
+                f'b=file://{fixture_path("empty.txt")}'
+            )
+            two = self.fetch_async(
+                "/html_source_dmp?format=json&"
+                f'a=file://{fixture_path("empty.txt")}&'
+                f'b=file://{fixture_path("empty.txt")}'
+            )
             response1, response2 = await asyncio.gather(one, two)
             assert response1.code == 200
             assert response2.code == 200
@@ -527,66 +594,75 @@ class ExecutionPoolTestCase(DiffingServerTestCase):
     # but better than no testing.
     @patch.object(df.DiffServer, "quit")
     def test_server_exits_if_process_pool_repeatedly_breaks(self, mock_quit):
-        # Set a custom executor that will always fail.
-        def get_executor(self, reset=False):
+        # Make async and use force_reset parameter
+        async def get_executor(self, force_reset=False):
             return BrokenProcessPoolExecutor()
 
-        with patch.object(df.DiffHandler, 'get_diff_executor', get_executor):
-            response = self.fetch('/html_source_dmp?format=json&'
-                                  f'a=file://{fixture_path("empty.txt")}&'
-                                  f'b=file://{fixture_path("empty.txt")}')
+        with patch.object(df.DiffExecutorManager, "get_executor", get_executor):
+            response = self.fetch(
+                "/html_source_dmp?format=json&"
+                f'a=file://{fixture_path("empty.txt")}&'
+                f'b=file://{fixture_path("empty.txt")}'
+            )
             self.json_check(response)
             assert response.code == 500
 
         assert mock_quit.called
-        assert mock_quit.call_args == ({'code': 10},)
+        assert mock_quit.call_args == ({"code": 10},)
 
     # NOTE: the real `quit` tears up the server, which causes porblems with
     # the test, so we just mock it and test that it was called, rather than
     # checking whether `sys.exit` was ultimately called. Not totally ideal,
     # but better than no testing.
     @patch.object(df.DiffServer, "quit")
-    @patch('web_monitoring_diff.server.server.RESTART_BROKEN_DIFFER', True)
-    def test_server_does_not_exit_if_env_var_set_when_process_pool_repeatedly_breaks(self, mock_quit):
-        # Set a custom executor that will always fail.
-        def get_executor(self, reset=False):
+    @patch("web_monitoring_diff.server.server.RESTART_BROKEN_DIFFER", True)
+    def test_server_does_not_exit_if_env_var_set_when_process_pool_repeatedly_breaks(
+        self, mock_quit
+    ):
+        # Make async and use force_reset parameter.
+        async def get_executor(self, force_reset=False):
             return BrokenProcessPoolExecutor()
 
-        with patch.object(df.DiffHandler, 'get_diff_executor', get_executor):
-            response = self.fetch('/html_source_dmp?format=json&'
-                                  f'a=file://{fixture_path("empty.txt")}&'
-                                  f'b=file://{fixture_path("empty.txt")}')
+        with patch.object(df.DiffExecutorManager, "get_executor", get_executor):
+            response = self.fetch(
+                "/html_source_dmp?format=json&"
+                f'a=file://{fixture_path("empty.txt")}&'
+                f'b=file://{fixture_path("empty.txt")}'
+            )
             self.json_check(response)
             assert response.code == 500
 
         assert not mock_quit.called
 
-
-    @patch('web_monitoring_diff.server.server.DIFFER_PARALLELISM', 2)
-    @patch('web_monitoring_diff.server.server.MAX_DIFFS_PER_WORKER', 2)
+    @patch("web_monitoring_diff.server.server.DIFFER_PARALLELISM", 2)
+    @patch("web_monitoring_diff.server.server.MAX_DIFFS_PER_WORKER", 2)
     @tornado.testing.gen_test
     async def test_max_diffs_per_worker(self):
         # The executor is created lazily, so do one request to create it.
-        response = await self.fetch_async('/html_source_dmp?format=json&'
-                                          f'a=file://{fixture_path("empty.txt")}&'
-                                          f'b=file://{fixture_path("empty.txt")}')
+        response = await self.fetch_async(
+            "/html_source_dmp?format=json&"
+            f'a=file://{fixture_path("empty.txt")}&'
+            f'b=file://{fixture_path("empty.txt")}'
+        )
         assert response.code == 200
-        original_executor = self._app.settings.get('diff_executor')
+        original_executor = self._app.executor_manager.executor
 
         # Make more than the max number of requests before restarting the diff
         # executor. This needs to be done in parallel so we can make sure
         # in-progress diffs don't get lost when rebuilding the executor.
         requests = [
-            self.fetch_async('/html_source_dmp?format=json&'
-                             f'a=file://{fixture_path("empty.txt")}&'
-                             f'b=file://{fixture_path("empty.txt")}')
+            self.fetch_async(
+                "/html_source_dmp?format=json&"
+                f'a=file://{fixture_path("empty.txt")}&'
+                f'b=file://{fixture_path("empty.txt")}'
+            )
             for _i in range(4)
         ]
         responses = await asyncio.gather(*requests)
         for response in responses:
             assert response.code == 200
 
-        executor = self._app.settings.get('diff_executor')
+        executor = self._app.executor_manager.executor
         assert original_executor is not executor
 
 
@@ -595,16 +671,16 @@ def mock_diffing_method(c_body):
 
 
 def fixture_path(fixture):
-    return Path(__file__).resolve().parent / 'fixtures' / fixture
+    return Path(__file__).resolve().parent / "fixtures" / fixture
 
 
 # TODO: merge this functionality in with MockAsyncHttpClient? It could have the
 # ability to serve a [fixture] file.
 def mock_tornado_request(fixture, headers=None):
     path = fixture_path(fixture)
-    with open(path, 'rb') as f:
+    with open(path, "rb") as f:
         body = f.read()
-        return MockResponse(f'file://{path}', body, headers)
+        return MockResponse(f"file://{path}", body, headers)
 
 
 # TODO: we may want to extract this to a support module
@@ -618,7 +694,7 @@ class MockAsyncHttpClient(AsyncHTTPClient):
         self.requests = {}
         self.stub_responses = []
 
-    def respond_to(self, matcher, code=200, body='', headers={}, error=None, **kwargs):
+    def respond_to(self, matcher, code=200, body="", headers={}, error=None, **kwargs):
         """
         Set up a fake HTTP response. If a request is made and no fake response
         set up with `respond_to()` matches it, an error will be raised.
@@ -647,58 +723,63 @@ class MockAsyncHttpClient(AsyncHTTPClient):
             regex = re.compile(matcher)
             matcher = lambda request: regex.search(request.url) is not None
 
-        if 'Content-Type' not in headers and 'content-type' not in headers:
-            headers['Content-Type'] = 'text/plain'
+        if "Content-Type" not in headers and "content-type" not in headers:
+            headers["Content-Type"] = "text/plain"
 
-        self.stub_responses.append({
-            'matcher': matcher,
-            'code': code,
-            'body': body,
-            'headers': headers,
-            'extra': kwargs,
-            'error': error
-        })
+        self.stub_responses.append(
+            {
+                "matcher": matcher,
+                "code": code,
+                "body": body,
+                "headers": headers,
+                "extra": kwargs,
+                "error": error,
+            }
+        )
 
     def fetch_impl(self, request, callback):
         stub = self._find_stub(request)
-        if stub['error']:
-            callback(HTTPResponse(request, 600, error=stub['error']))
+        if stub["error"]:
+            callback(HTTPResponse(request, 600, error=stub["error"]))
             return
 
-        buffer = BytesIO(utf8(stub['body']))
-        headers = HTTPHeaders(stub['headers'])
-        response = HTTPResponse(request, stub['code'], buffer=buffer,
-                                headers=headers, **stub['extra'])
+        buffer = BytesIO(utf8(stub["body"]))
+        headers = HTTPHeaders(stub["headers"])
+        response = HTTPResponse(
+            request, stub["code"], buffer=buffer, headers=headers, **stub["extra"]
+        )
         self.requests[request.url] = request
         callback(response)
 
     def _find_stub(self, request):
         for stub in self.stub_responses:
-            if stub['matcher'](request):
+            if stub["matcher"](request):
                 return stub
-        raise ValueError(f'No response stub for {request.url}')
+        raise ValueError(f"No response stub for {request.url}")
 
 
 class MockResponderHeadersTest(unittest.TestCase):
     def test_pdf_extension(self):
-        response = MockResponse(f'file://{fixture_path("simple.pdf")}', '')
-        assert response.headers['Content-Type'] == 'application/pdf'
+        response = MockResponse(f'file://{fixture_path("simple.pdf")}', "")
+        assert response.headers["Content-Type"] == "application/pdf"
 
     def test_html_extension(self):
-        response = MockResponse(f'file://{fixture_path("unknown_encoding.html")}', '')
-        assert response.headers['Content-Type'] == 'text/html'
+        response = MockResponse(f'file://{fixture_path("unknown_encoding.html")}', "")
+        assert response.headers["Content-Type"] == "text/html"
 
     def test_txt_extension(self):
-        response = MockResponse(f'file://{fixture_path("empty.txt")}', '')
-        assert response.headers['Content-Type'] == 'text/plain'
+        response = MockResponse(f'file://{fixture_path("empty.txt")}', "")
+        assert response.headers["Content-Type"] == "text/plain"
 
     def test_no_extension_should_assume_html(self):
-        response = MockResponse(f'file://{fixture_path("unknown_encoding")}', '')
-        assert response.headers['Content-Type'] == 'text/html'
+        response = MockResponse(f'file://{fixture_path("unknown_encoding")}', "")
+        assert response.headers["Content-Type"] == "text/html"
 
     def test_unknown_extension_should_assume_html(self):
-        response = MockResponse(f'file://{fixture_path("unknown_encoding.notarealextension")}', '')
-        assert response.headers['Content-Type'] == 'text/html'
+        response = MockResponse(
+            f'file://{fixture_path("unknown_encoding.notarealextension")}', ""
+        )
+        assert response.headers["Content-Type"] == "text/html"
 
 
 class SimpleHttpServer:
@@ -712,12 +793,13 @@ class SimpleHttpServer:
         Called whenever a request is made to the server. The first parameter
         will be a Tornado `RequestHandler` instance.
     """
+
     def __init__(self, handler):
         sock, port = bind_unused_port()
         self._port = port
-        self._app = tornado.web.Application([(r".*", SimpleHttpServerHandler)],
-                                            debug=True,
-                                            actual_handler=handler)
+        self._app = tornado.web.Application(
+            [(r".*", SimpleHttpServerHandler)], debug=True, actual_handler=handler
+        )
         self.http_server = HTTPServer(self._app)
         self.http_server.add_sockets([sock])
 
@@ -725,7 +807,7 @@ class SimpleHttpServer:
         self.http_server.stop()
 
     def url(self, path):
-        return f'http://localhost:{self._port}{path}'
+        return f"http://localhost:{self._port}{path}"
 
     def __enter__(self):
         return self
@@ -736,5 +818,5 @@ class SimpleHttpServer:
 
 class SimpleHttpServerHandler(tornado.web.RequestHandler):
     async def get(self):
-        handler = self.settings.get('actual_handler')
+        handler = self.settings.get("actual_handler")
         await handler(self)


### PR DESCRIPTION
In previously server.py had many things to care, it had to handle web requests and  also at the same time it had to responsible for:
- Creating and destroying a process pool
- Counting how many diffs each worker had run
- Deciding when to recycle workers
- Recovering from crashed worker processes
- Deciding whether to shut the whole server down

As the issue #243 explains, the crash recovery logic was tangled inside the HTTP request handler. The pool state was also stored loosely in Tornado's settings dictionary instead of a proper separated object. This made it hard to understand and test independently from the web serving code. 
So I extracted all process pool logic into a new class DiffExecutorManager in a new file executor.py. 

executor.py now owns:
- Creating the ProcessPoolExecutor
- Tracking remaining_diffs to know when to recycle workers
- Retrying after a BrokenProcessPool crash
- Graceful vs immediate shutdown of worker processes
- Raising DiffPoolError when the situation is unrecoverable 

server.py is now only responsible for:
- Receiving HTTP requests
- Fetching content from URLs
- Asking the executor manager to run a diff
- Formatting and returning the response 

Because of this change, if the ProcessPoolExecutor crashes, the web server keeps running normally. Only the worker pool gets recycled inside DiffExecutorManager  and the HTTP server and request handling in server.py are completely safe and unaffected.

Close issue(#243)
@Mr0grog 