### PR TITLE
refactor(server): extract PublicError and LimitedCurlAsyncHTTPClient into separate modules

### DIFF
--- a/web_monitoring_diff/server/errors.py
+++ b/web_monitoring_diff/server/errors.py
@@ -35,3 +35,4 @@ class PublicError(tornado.web.HTTPError):
                 log_message = public_message
 
         super().__init__(status_code, log_message, **kwargs)
+        

--- a/web_monitoring_diff/server/errors.py
+++ b/web_monitoring_diff/server/errors.py
@@ -35,4 +35,3 @@ class PublicError(tornado.web.HTTPError):
                 log_message = public_message
 
         super().__init__(status_code, log_message, **kwargs)
-        

--- a/web_monitoring_diff/server/errors.py
+++ b/web_monitoring_diff/server/errors.py
@@ -1,0 +1,37 @@
+import tornado.web
+
+
+class PublicError(tornado.web.HTTPError):
+    """
+    Customized version of Tornado's HTTP error designed for reporting publicly
+    visible error messages. Please always raise this instead of calling
+    `send_error()` directly, since it lets you attach a user-visible
+    explanation of what went wrong.
+
+    Parameters
+    ----------
+    status_code : int, default: 500
+        Status code for the response.
+    public_message : str, optional
+        Textual description of the error. This will be publicly visible in
+        production mode, unlike `log_message`.
+    log_message : str, optional
+        Error message written to logs and to error tracking service. Will be
+        included in the HTTP response only in debug mode. Same as the
+        `log_message` parameter to `tornado.web.HTTPError`, but with no
+        interpolation.
+    extra : dict, optional
+        Dict of additional keys and values to include in the error response.
+    """
+    def __init__(self, status_code=500, public_message=None, log_message=None,
+                 extra=None, **kwargs):
+        self.extra = extra or {}
+
+        if public_message is not None:
+            if 'error' not in self.extra:
+                self.extra['error'] = public_message
+
+            if log_message is None:
+                log_message = public_message
+
+        super().__init__(status_code, log_message, **kwargs)

--- a/web_monitoring_diff/server/http_client.py
+++ b/web_monitoring_diff/server/http_client.py
@@ -1,0 +1,23 @@
+import pycurl
+from tornado.curl_httpclient import CurlAsyncHTTPClient
+
+
+class LimitedCurlAsyncHTTPClient(CurlAsyncHTTPClient):
+    """
+    A customized version of Tornado's CurlAsyncHTTPClient that adds support for
+    maximum response body sizes. The API is the same as that for Tornado's
+    SimpleAsyncHTTPClient: set ``max_body_size`` to an integer representing the
+    maximum number of bytes in a response body.
+    """
+    def initialize(self, max_clients=10, defaults=None, max_body_size=None):
+        self.max_body_size = max_body_size
+        defaults = defaults or {}
+        defaults['prepare_curl_callback'] = self.prepare_curl
+        super().initialize(max_clients=max_clients, defaults=defaults)
+
+    def prepare_curl(self, curl):
+        if self.max_body_size:
+            # NOTE: cURL's docs suggest this doesn't work if the server doesn't
+            # send a Content-Length header, but it seems to do just fine in
+            # tests. ¯\_(ツ)_/¯
+            curl.setopt(pycurl.MAXFILESIZE, self.max_body_size)

--- a/web_monitoring_diff/server/http_client.py
+++ b/web_monitoring_diff/server/http_client.py
@@ -21,3 +21,4 @@ class LimitedCurlAsyncHTTPClient(CurlAsyncHTTPClient):
             # send a Content-Length header, but it seems to do just fine in
             # tests. ¯\_(ツ)_/¯
             curl.setopt(pycurl.MAXFILESIZE, self.max_body_size)
+            

--- a/web_monitoring_diff/server/http_client.py
+++ b/web_monitoring_diff/server/http_client.py
@@ -21,4 +21,3 @@ class LimitedCurlAsyncHTTPClient(CurlAsyncHTTPClient):
             # send a Content-Length header, but it seems to do just fine in
             # tests. ¯\_(ツ)_/¯
             curl.setopt(pycurl.MAXFILESIZE, self.max_body_size)
-            

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -21,6 +21,7 @@ import tornado.web
 import traceback
 import web_monitoring_diff
 from .mock_http import MockResponse
+from .errors import PublicError
 from .. import basic_diffs, html_render_diff, html_links_diff
 from ..exceptions import UndiffableContentError, UndecodableContentError
 from ..utils import shutdown_executor_in_loop, Signal
@@ -132,42 +133,6 @@ tornado.httpclient.AsyncHTTPClient.configure(HTTP_CLIENT,
 
 def get_http_client():
     return tornado.httpclient.AsyncHTTPClient()
-
-
-class PublicError(tornado.web.HTTPError):
-    """
-    Customized version of Tornado's HTTP error designed for reporting publicly
-    visible error messages. Please always raise this instead of calling
-    `send_error()` directly, since it lets you attach a user-visible
-    explanation of what went wrong.
-
-    Parameters
-    ----------
-    status_code : int, default: 500
-        Status code for the response.
-    public_message : str, optional
-        Textual description of the error. This will be publicly visible in
-        production mode, unlike `log_message`.
-    log_message : str, optional
-        Error message written to logs and to error tracking service. Will be
-        included in the HTTP response only in debug mode. Same as the
-        `log_message` parameter to `tornado.web.HTTPError`, but with no
-        interpolation.
-    extra : dict, optional
-        Dict of additional keys and values to include in the error response.
-    """
-    def __init__(self, status_code=500, public_message=None, log_message=None,
-                 extra=None, **kwargs):
-        self.extra = extra or {}
-
-        if public_message is not None:
-            if 'error' not in self.extra:
-                self.extra['error'] = public_message
-
-            if log_message is None:
-                log_message = public_message
-
-        super().__init__(status_code, log_message, **kwargs)
 
 
 DEBUG_MODE = os.environ.get('DIFFING_SERVER_DEBUG', 'False').strip().lower() == 'true'

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -13,7 +13,7 @@ import sentry_sdk
 import signal
 import sys
 from dotenv import load_dotenv
-from tornado.curl_httpclient import CurlAsyncHTTPClient, CurlError
+from tornado.curl_httpclient import CurlError
 import tornado.simple_httpclient
 import tornado.httpclient
 import tornado.ioloop

--- a/web_monitoring_diff/server/server.py
+++ b/web_monitoring_diff/server/server.py
@@ -22,6 +22,7 @@ import traceback
 import web_monitoring_diff
 from .mock_http import MockResponse
 from .errors import PublicError
+from .http_client import LimitedCurlAsyncHTTPClient
 from .. import basic_diffs, html_render_diff, html_links_diff
 from ..exceptions import UndiffableContentError, UndecodableContentError
 from ..utils import shutdown_executor_in_loop, Signal
@@ -101,27 +102,6 @@ try:
 except ValueError:
     print('DIFFER_MAX_BODY_SIZE must be an integer', file=sys.stderr)
     sys.exit(1)
-
-
-class LimitedCurlAsyncHTTPClient(CurlAsyncHTTPClient):
-    """
-    A customized version of Tornado's CurlAsyncHTTPClient that adds support for
-    maximum response body sizes. The API is the same as that for Tornado's
-    SimpleAsyncHTTPClient: set ``max_body_size`` to an integer representing the
-    maximum number of bytes in a response body.
-    """
-    def initialize(self, max_clients=10, defaults=None, max_body_size=None):
-        self.max_body_size = max_body_size
-        defaults = defaults or {}
-        defaults['prepare_curl_callback'] = self.prepare_curl
-        super().initialize(max_clients=max_clients, defaults=defaults)
-
-    def prepare_curl(self, curl):
-        if self.max_body_size:
-            # NOTE: cURL's docs suggest this doesn't work if the server doesn't
-            # send a Content-Length header, but it seems to do just fine in
-            # tests. ¯\_(ツ)_/¯
-            curl.setopt(pycurl.MAXFILESIZE, self.max_body_size)
 
 
 HTTP_CLIENT = LimitedCurlAsyncHTTPClient


### PR DESCRIPTION
Closes #28

This PR extracts a couple of custom classes from `server.py` into
separate modules to make the file easier to navigate and maintain.

- moved `PublicError` to `server/errors.py`
- moved `LimitedCurlAsyncHTTPClient` to `server/http_client.py`
- updated imports in `server.py`

No functional changes intended.